### PR TITLE
Handle I/O errors more gracefully

### DIFF
--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -1,5 +1,6 @@
 import atexit
 import base64
+import errno
 import os
 import sys
 from os.path import dirname, exists
@@ -21,6 +22,17 @@ DEFERRED = []
 # uses a lock to ensure that only one thread even attempts.
 CACHE = {}
 LOCK = RLock()
+
+# Causes tokens reads to fail (for testing). The string should contain
+# the token types that should fail; e.g., c, s, e
+READ_CHAOS = os.environ.get("ANACONDA_ANON_USAGE_READ_CHAOS") or ""
+# Causes token writes to fail (for testing). The string should contain
+# the token types that should fail; c, e
+WRITE_CHAOS = os.environ.get("ANACONDA_ANON_USAGE_WRITE_CHAOS") or ""
+
+WRITE_SUCCESS = 0
+WRITE_DEFER = 1
+WRITE_FAIL = 2
 
 
 def cached(func):
@@ -45,6 +57,16 @@ def _cache_clear():
 
 
 def _debug(s, *args, error=False):
+    if error and not DEBUG:
+        # Suppress error output in --json mode. This accommodates
+        # processes that might be using --json mode and merging
+        # stdout and stderr together. If DEBUG is True we assume
+        # this accommodation is not necessary. The import is
+        # deferred here as well to reduce the likelihood of a
+        # circular import issue.
+        from conda.base.context import context
+
+        error = not context.json
     if error or DEBUG:
         print((DPREFIX + s) % args, file=sys.stderr)
 
@@ -70,22 +92,35 @@ def _final_attempt():
 atexit.register(_final_attempt)
 
 
-def _write_attempt(must_exist, fpath, client_token):
+def _write_attempt(must_exist, fpath, client_token, emulate_fail=False):
     """
     Attempt to write the token to the given location.
     Return True with success, False otherwise.
     """
     if must_exist and not exists(must_exist):
         _debug("Directory not ready: %s", must_exist)
-        return False
+        return WRITE_DEFER
     try:
+        if emulate_fail:
+            raise OSError(errno.EROFS, "Testing permissions issues")
         os.makedirs(dirname(fpath), exist_ok=True)
         with open(fpath, "w") as fp:
             fp.write(client_token)
         _debug("Token saved: %s", fpath)
-        return True
+        return WRITE_SUCCESS
     except Exception as exc:
-        _debug("Unexpected error writing: %s\n  %s", fpath, exc, error=True)
+        # If we get here, a second attempt is unlikely to succeed,
+        # so we return True so that we don't schedule the re-attempt.
+        if getattr(exc, "errno", None) in (errno.EACCES, errno.EPERM, errno.EROFS):
+            _debug("No write permissions; cannot write token")
+        else:
+            _debug(
+                "Unexpected error writing token file:\n  path: %s\n  exception: %s",
+                fpath,
+                exc,
+                error=True,
+            )
+        return WRITE_FAIL
 
 
 def _saved_token(fpath, what, must_exist=None):
@@ -98,7 +133,9 @@ def _saved_token(fpath, what, must_exist=None):
     global DEFERRED
     client_token = ""
     _debug("%s token path: %s", what.capitalize(), fpath)
-    if exists(fpath):
+    if what[0] in READ_CHAOS:
+        _debug("Pretending %s token is not present", what)
+    elif exists(fpath):
         try:
             # Use just the first line of the file, if it exists
             with open(fpath) as fp:
@@ -110,7 +147,11 @@ def _saved_token(fpath, what, must_exist=None):
         if len(client_token) > 0:
             _debug("Generating longer token")
         client_token = _random_token(what)
-        if not _write_attempt(must_exist, fpath, client_token):
+        status = _write_attempt(must_exist, fpath, client_token, what[0] in WRITE_CHAOS)
+        if status == WRITE_FAIL:
+            _debug("Returning blank %s token", what)
+            return ""
+        if status == WRITE_DEFER:
             # If the environment has not yet been created we need
             # to defer the token write until later.
             _debug("Deferring token write")

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -110,7 +110,7 @@ def _write_attempt(must_exist, fpath, client_token, emulate_fail=False):
         return WRITE_SUCCESS
     except Exception as exc:
         # If we get here, a second attempt is unlikely to succeed,
-        # so we return True so that we don't schedule the re-attempt.
+        # so we return a code to indicate that we should not re-attempt.
         if getattr(exc, "errno", None) in (errno.EACCES, errno.EPERM, errno.EROFS):
             _debug("No write permissions; cannot write token")
         else:

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -151,7 +151,7 @@ def _saved_token(fpath, what, must_exist=None):
         if status == WRITE_FAIL:
             _debug("Returning blank %s token", what)
             return ""
-        if status == WRITE_DEFER:
+        elif status == WRITE_DEFER:
             # If the environment has not yet been created we need
             # to defer the token write until later.
             _debug("Deferring token write")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,6 @@ def client_token_string_cache_cleanup(request):
     request.addfinalizer(utils._cache_clear)
 
 
-@pytest.fixture(autouse=True)
-def client_token_string_clear_chaos(request):
-    def _cleanup():
-        utils.READ_CHAOS = utils.WRITE_CHAOS = ""
-
-    request.addfinalizer(_cleanup)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,7 @@ from os.path import join
 import pytest
 from conda.base.context import Context
 
-from anaconda_anon_usage import tokens
-from anaconda_anon_usage.utils import _cache_clear
+from anaconda_anon_usage import tokens, utils
 
 
 @pytest.fixture
@@ -26,7 +25,15 @@ def token_cleanup(request, aau_token_path):
 
 @pytest.fixture(autouse=True)
 def client_token_string_cache_cleanup(request):
-    request.addfinalizer(_cache_clear)
+    request.addfinalizer(utils._cache_clear)
+
+
+@pytest.fixture(autouse=True)
+def client_token_string_clear_chaos(request):
+    def _cleanup():
+        utils.READ_CHAOS = utils.WRITE_CHAOS = ""
+
+    request.addfinalizer(_cleanup)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,6 @@ def client_token_string_cache_cleanup(request):
     request.addfinalizer(utils._cache_clear)
 
 
-
-
 @pytest.fixture(autouse=True)
 def reset_patch(request):
     def _resetter():

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,6 +1,6 @@
 from os.path import exists
 
-from anaconda_anon_usage import tokens
+from anaconda_anon_usage import tokens, utils
 
 
 def test_client_token(aau_token_path):
@@ -50,6 +50,22 @@ def test_token_string_no_environment_token(
 ):
     monkeypatch.setattr(tokens, "environment_token", lambda prefix: "")
 
+    token_string = tokens.token_string()
+    assert "c/" in token_string
+    assert "s/" in token_string
+    assert "e/" not in token_string
+
+
+def test_token_string_full_readonly():
+    utils.READ_CHAOS = utils.WRITE_CHAOS = "ce"
+    token_string = tokens.token_string()
+    assert "c/" not in token_string
+    assert "s/" in token_string
+    assert "e/" not in token_string
+
+
+def test_token_string_env_readonly():
+    utils.READ_CHAOS = utils.WRITE_CHAOS = "e"
     token_string = tokens.token_string()
     assert "c/" in token_string
     assert "s/" in token_string

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -56,16 +56,19 @@ def test_token_string_no_environment_token(
     assert "e/" not in token_string
 
 
-def test_token_string_full_readonly():
-    utils.READ_CHAOS = utils.WRITE_CHAOS = "ce"
+def test_token_string_full_readonly(monkeypatch):
+    monkeypatch.setattr(utils, "READ_CHAOS", "ce")
+    monkeypatch.setattr(utils, "WRITE_CHAOS", "ce")
     token_string = tokens.token_string()
     assert "c/" not in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
 
 
-def test_token_string_env_readonly():
-    utils.READ_CHAOS = utils.WRITE_CHAOS = "e"
+def test_token_string_env_readonly(monkeypatch):
+    monkeypatch.setattr(utils, "READ_CHAOS", "e")
+    monkeypatch.setattr(utils, "WRITE_CHAOS", "e")
+
     token_string = tokens.token_string()
     assert "c/" in token_string
     assert "s/" in token_string

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -36,9 +36,36 @@ def test_saved_token_exception(tmpdir):
     token_path = tmpdir.join("aau_token")
     # setting this up as a directory to trigger the exists
     token_path.mkdir()
-    utils._saved_token(token_path, "test")
+    token_value = utils._saved_token(token_path, "test")
+    assert not token_value
     assert exists(token_path)
     assert isdir(token_path)
+    assert token_value == ""
+
+
+def test_read_chaos(tmpdir):
+    token_path = tmpdir.join("aau_token")
+    token1 = utils._saved_token(token_path, "environment")
+    assert token1
+    utils.READ_CHAOS = "e"
+    token2 = utils._saved_token(token_path, "environment")
+    assert token2 and token1 != token2
+    utils.READ_CHAOS = ""
+    token3 = utils._saved_token(token_path, "environment")
+    assert token3 == token2
+
+
+def test_write_chaos(tmpdir):
+    token_path = tmpdir.join("aau_token")
+    utils.WRITE_CHAOS = "e"
+    token1 = utils._saved_token(token_path, "environment")
+    assert not token1 and not token_path.exists()
+    utils.WRITE_CHAOS = ""
+    token2 = utils._saved_token(token_path, "environment")
+    assert token2 and token_path.exists()
+    utils.WRITE_CHAOS = "e"
+    token3 = utils._saved_token(token_path, "environment")
+    assert token3 == token2
 
 
 def test_saved_token_existing_short(tmpdir):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -43,27 +43,27 @@ def test_saved_token_exception(tmpdir):
     assert token_value == ""
 
 
-def test_read_chaos(tmpdir):
+def test_read_chaos(monkeypatch, tmpdir):
     token_path = tmpdir.join("aau_token")
     token1 = utils._saved_token(token_path, "environment")
     assert token1
-    utils.READ_CHAOS = "e"
+    monkeypatch.setattr(utils, "READ_CHAOS", "e")
     token2 = utils._saved_token(token_path, "environment")
     assert token2 and token1 != token2
-    utils.READ_CHAOS = ""
+    monkeypatch.setattr(utils, "READ_CHAOS", "")
     token3 = utils._saved_token(token_path, "environment")
     assert token3 == token2
 
 
-def test_write_chaos(tmpdir):
+def test_write_chaos(monkeypatch, tmpdir):
     token_path = tmpdir.join("aau_token")
-    utils.WRITE_CHAOS = "e"
+    monkeypatch.setattr(utils, "WRITE_CHAOS", "e")
     token1 = utils._saved_token(token_path, "environment")
     assert not token1 and not token_path.exists()
-    utils.WRITE_CHAOS = ""
+    monkeypatch.setattr(utils, "WRITE_CHAOS", "")
     token2 = utils._saved_token(token_path, "environment")
     assert token2 and token_path.exists()
-    utils.WRITE_CHAOS = "e"
+    monkeypatch.setattr(utils, "WRITE_CHAOS", "e")
     token3 = utils._saved_token(token_path, "environment")
     assert token3 == token2
 


### PR DESCRIPTION
Handling read-only situations better.

- Since read-only environments are a reality, they shouldn't be treated as "Unexpected" errors.
- Add some tests to emulate missing files and read-only situations
- Return empty strings if a token cannot be written to disk, so we don't pollute data with random per-use tokens 
- If there are errors, don't output them in --json mode

To test the condition that led to this PR, run:

```
ANACONDA_ANON_USAGE_READ_CHAOS=e ANACONDA_ANON_USAGE_WRITE_CHAOS=e conda info --json
```

You should see nothing but valid --json output