### PR TITLE
fix script paths, and absorb exceptions

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,14 +1,14 @@
-echo on
 setlocal EnableDelayedExpansion
 %PREFIX%\python.exe -m pip install --no-deps --ignore-installed -vv .
 if "%NEED_SCRIPTS%" neq "yes" del %SP_DIR%\anaconda_anon_usage\install.py
-if "%NEED_SCRIPTS%" equ "yes" del %SP_DIR%\anaconda_anon_usage\plugin.py
 if "%NEED_SCRIPTS%" neq "yes" exit
+del %SP_DIR%\anaconda_anon_usage\plugin.py
 if not exist %PREFIX%\etc\conda\activate.d mkdir %PREFIX%\etc\conda\activate.d
-if not exist %PREFIX%\python-scripts mkdir %PREFIX%\python-scripts
-copy scripts\activate.sh    %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.sh
-copy scripts\activate.bat   %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat
-copy scripts\post-link.sh   %PREFIX%\python-scripts\.%PKG_NAME%-post-link.sh
-copy scripts\post-link.bat  %PREFIX%\python-scripts\.%PKG_NAME%-post-link.bat
-copy scripts\pre-unlink.sh  %PREFIX%\python-scripts\.%PKG_NAME%-pre-unlink.sh
-copy scripts\pre-unlink.bat %PREFIX%\python-scripts\.%PKG_NAME%-pre-unlink.bat
+copy scripts\activate.sh %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.sh
+copy scripts\activate.bat %PREFIX%\etc\conda\activate.d\%PKG_NAME%_activate.bat
+if not exist %PREFIX%\Scripts mkdir %PREFIX%\Scripts
+copy scripts\post-link.bat %PREFIX%\Scripts\.%PKG_NAME%-post-link.bat
+copy scripts\pre-unlink.bat %PREFIX%\Scripts\.%PKG_NAME%-pre-unlink.bat
+if not exist %PREFIX%\bin mkdir %PREFIX%\bin
+copy scripts\post-link.sh %PREFIX%\bin\.%PKG_NAME%-post-link.sh
+copy scripts\pre-unlink.sh %PREFIX%\bin\.%PKG_NAME%-pre-unlink.sh

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -3,17 +3,11 @@
 if [ "$NEED_SCRIPTS" != yes ]; then
     rm ${SP_DIR}/anaconda_anon_usage/install.py
     exit 0
-else
-    rm ${SP_DIR}/anaconda_anon_usage/plugin.py
 fi
-mkdir -p "${PREFIX}/etc/conda/activate.d"
+rm ${SP_DIR}/anaconda_anon_usage/plugin.py
+if [ "$SUBDIR" = "noarch" ]; then sdir=python-scripts; else sdir=bin; fi
+mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/${sdir}"
 cp "scripts/activate.sh" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
-if [ "$SUBDIR" = "noarch" ]; then
-    sdir=python-scripts
-else
-    sdir=bin
-fi
-mkdir -p "${PREFIX}/${sdir}"
 cp "scripts/post-link.sh" "${PREFIX}/${sdir}/.${PKG_NAME}-post-link.sh"
 cp "scripts/pre-unlink.sh" "${PREFIX}/${sdir}/.${PKG_NAME}-pre-unlink.sh"
 if [ "$SUBDIR" = "noarch" ]; then

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 "${PREFIX}/bin/python" -m pip install --no-deps --ignore-installed -vv .
 if [ "$NEED_SCRIPTS" != yes ]; then
     rm ${SP_DIR}/anaconda_anon_usage/install.py
@@ -6,10 +7,17 @@ else
     rm ${SP_DIR}/anaconda_anon_usage/plugin.py
 fi
 mkdir -p "${PREFIX}/etc/conda/activate.d"
-mkdir -p "${PREFIX}/python-scripts"
-cp "scripts/activate.sh"    "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
-cp "scripts/activate.bat"   "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.bat"
-cp "scripts/post-link.sh"   "${PREFIX}/python-scripts/.${PKG_NAME}-post-link.sh"
-cp "scripts/pre-unlink.sh"  "${PREFIX}/python-scripts/.${PKG_NAME}-pre-unlink.sh"
-cp "scripts/post-link.bat"  "${PREFIX}/python-scripts/.${PKG_NAME}-post-link.bat"
-cp "scripts/pre-unlink.bat" "${PREFIX}/python-scripts/.${PKG_NAME}-pre-unlink.bat"
+cp "scripts/activate.sh" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
+if [ "$SUBDIR" = "noarch" ]; then
+    sdir=python-scripts
+else
+    sdir=bin
+fi
+mkdir -p "${PREFIX}/${sdir}"
+cp "scripts/post-link.sh" "${PREFIX}/${sdir}/.${PKG_NAME}-post-link.sh"
+cp "scripts/pre-unlink.sh" "${PREFIX}/${sdir}/.${PKG_NAME}-pre-unlink.sh"
+if [ "$SUBDIR" = "noarch" ]; then
+    cp "scripts/activate.bat" "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.bat"
+    cp "scripts/post-link.bat" "${PREFIX}/${sdir}/.${PKG_NAME}-post-link.bat"
+    cp "scripts/pre-unlink.bat" "${PREFIX}/${sdir}/.${PKG_NAME}-pre-unlink.bat"
+fi

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set data = load_setup_py_data() %}
+{% set number = 0 %}
 
 package:
   name: anaconda-anon-usage
@@ -8,6 +9,11 @@ source:
   path: ..
 
 build:
+  # Use a build number difference to ensure that the plugin
+  # variant is slightly preferred by conda's solver.
+  number: {{ number + 100 }}  # [variant=="plugin"]
+  number: {{ number }}        # [variant=="patch"]
+  string: py_{{ PKG_BUILDNUM }}
   noarch: python  # [not win]
   script_env:
    - NEED_SCRIPTS=no   # [variant=="plugin"]

--- a/scripts/activate.bat
+++ b/scripts/activate.bat
@@ -1,1 +1,1 @@
-@%CONDA_PREFIX%\python.exe -m anaconda_anon_usage.install --enable --quiet
+@"%CONDA_PREFIX%\python.exe" -m anaconda_anon_usage.install --enable --quiet

--- a/scripts/activate.bat
+++ b/scripts/activate.bat
@@ -1,1 +1,1 @@
-@python -m anaconda_anon_usage.install --enable --quiet
+@%CONDA_PREFIX%\python.exe -m anaconda_anon_usage.install --enable --quiet

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,3 +1,3 @@
 pbin="${CONDA_PREFIX}/python.exe"
 [ -f "${pbin}" ] || pbin="${CONDA_PREFIX}/bin/python"
-"${pbin}" -m anaconda_anon_usage.install --enable --quiet
+"${pbin}" -m anaconda_anon_usage.install --enable --quiet || :

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,1 +1,3 @@
-python -m anaconda_anon_usage.install --enable --quiet
+pbin=${CONDA_PREFIX}/python.exe
+[ -f ${pbin} ] || pbin=${CONDA_PREFIX}/bin/python
+${pbin} -m anaconda_anon_usage.install --enable --quiet

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,3 +1,3 @@
-pbin=${CONDA_PREFIX}/python.exe
-[ -f ${pbin} ] || pbin=${CONDA_PREFIX}/bin/python
-${pbin} -m anaconda_anon_usage.install --enable --quiet
+pbin="${CONDA_PREFIX}/python.exe"
+[ -f "${pbin}" ] || pbin="${CONDA_PREFIX}/bin/python"
+"${pbin}" -m anaconda_anon_usage.install --enable --quiet

--- a/scripts/post-link.bat
+++ b/scripts/post-link.bat
@@ -1,3 +1,3 @@
 @echo off
-if "%CONDA_PREFIX%"=="" (set "pfx=%PREFIX%") else (set "pfx=%CONDA_PREFIX%")
-%pfx%\python.exe -m anaconda_anon_usage.install --enable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+if "%CONDA_PREFIX%"=="" (set pfx="%PREFIX%") else (set pfx="%CONDA_PREFIX%")
+"%pfx%\python.exe" -m anaconda_anon_usage.install --enable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/scripts/post-link.bat
+++ b/scripts/post-link.bat
@@ -1,3 +1,3 @@
 @echo off
 if "%CONDA_PREFIX%"=="" (set "pfx=%PREFIX%") else (set "pfx=%CONDA_PREFIX%")
-python -m anaconda_anon_usage.install --enable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+%pfx%\python.exe -m anaconda_anon_usage.install --enable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/scripts/post-link.bat
+++ b/scripts/post-link.bat
@@ -1,3 +1,3 @@
 @echo off
 if "%CONDA_PREFIX%"=="" (set pfx="%PREFIX%") else (set pfx="%CONDA_PREFIX%")
-"%pfx%\python.exe" -m anaconda_anon_usage.install --enable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+"%pfx%\python.exe" -m anaconda_anon_usage.install --enable --quiet >>"%pfx%\.messages.txt" 2>&1

--- a/scripts/post-link.sh
+++ b/scripts/post-link.sh
@@ -1,4 +1,6 @@
-pfx=${CONDA_PREFIX:-${PREFIX:-}}
-pbin=${pfx}/python.exe
-[ -f ${pbin} ] || pbin=${pfx}/bin/python
-${pbin} -m anaconda_anon_usage.install --enable --quiet >>"${pfx}/.messages.txt" 2>&1
+#!/bin/sh
+
+pfx="${CONDA_PREFIX:-${PREFIX:-}}"
+pbin="${pfx}/python.exe"
+[ -f "${pbin}" ] || pbin="${pfx}/bin/python"
+"${pbin}" -m anaconda_anon_usage.install --enable --quiet >>"${pfx}/.messages.txt" 2>&1

--- a/scripts/post-link.sh
+++ b/scripts/post-link.sh
@@ -3,4 +3,4 @@
 pfx="${CONDA_PREFIX:-${PREFIX:-}}"
 pbin="${pfx}/python.exe"
 [ -f "${pbin}" ] || pbin="${pfx}/bin/python"
-"${pbin}" -m anaconda_anon_usage.install --enable --quiet >>"${pfx}/.messages.txt" 2>&1
+"${pbin}" -m anaconda_anon_usage.install --enable --quiet >>"${pfx}/.messages.txt" 2>&1 || :

--- a/scripts/pre-unlink.bat
+++ b/scripts/pre-unlink.bat
@@ -1,3 +1,3 @@
 @echo off
 if "%CONDA_PREFIX%"=="" (set pfx="%PREFIX%") else (set "pfx=%CONDA_PREFIX%")
-"%pfx%\python.exe" -m anaconda_anon_usage.install --disable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+"%pfx%\python.exe" -m anaconda_anon_usage.install --disable --quiet >>"%pfx%\.messages.txt" 2>&1

--- a/scripts/pre-unlink.bat
+++ b/scripts/pre-unlink.bat
@@ -1,3 +1,3 @@
 @echo off
 if "%CONDA_PREFIX%"=="" (set "pfx=%PREFIX%") else (set "pfx=%CONDA_PREFIX%")
-python -m anaconda_anon_usage.install --disable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+%pfx%\python.exe -m anaconda_anon_usage.install --disable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/scripts/pre-unlink.bat
+++ b/scripts/pre-unlink.bat
@@ -1,3 +1,3 @@
 @echo off
-if "%CONDA_PREFIX%"=="" (set "pfx=%PREFIX%") else (set "pfx=%CONDA_PREFIX%")
-%pfx%\python.exe -m anaconda_anon_usage.install --disable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+if "%CONDA_PREFIX%"=="" (set pfx="%PREFIX%") else (set "pfx=%CONDA_PREFIX%")
+"%pfx%\python.exe" -m anaconda_anon_usage.install --disable --quiet >>"%pfx%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/scripts/pre-unlink.sh
+++ b/scripts/pre-unlink.sh
@@ -3,4 +3,4 @@
 pfx="${CONDA_PREFIX:-${PREFIX:-}}"
 pbin="${pfx}/python.exe"
 [ -f "${pbin}" ] || pbin="${pfx}/bin/python"
-"${pbin}" -m anaconda_anon_usage.install --disable --quiet >>"${pfx}/.messages.txt" 2>&1
+"${pbin}" -m anaconda_anon_usage.install --disable --quiet >>"${pfx}/.messages.txt" 2>&1 || :

--- a/scripts/pre-unlink.sh
+++ b/scripts/pre-unlink.sh
@@ -1,4 +1,6 @@
-pfx=${CONDA_PREFIX:-${PREFIX:-}}
-pbin=${pfx}/python.exe
-[ -f ${pbin} ] || pbin=${pfx}/bin/python
-${pbin} -m anaconda_anon_usage.install --disable --quiet >>"${pfx}/.messages.txt" 2>&1
+#!/bin/sh
+
+pfx="${CONDA_PREFIX:-${PREFIX:-}}"
+pbin="${pfx}/python.exe"
+[ -f "${pbin}" ] || pbin="${pfx}/bin/python"
+"${pbin}" -m anaconda_anon_usage.install --disable --quiet >>"${pfx}/.messages.txt" 2>&1


### PR DESCRIPTION
Under certain circumstances—within conda build for instance—it seems that we cannot rely on the conda environment's python to be first on the PATH. So we need to be explicit about using the conda environment's python in post-link and activate scripting.

I'm also adding exception absorption for the scripts (activate, post-link, pre-unlink). If the scripts fail, we can't afford to interrupt user workflows. Note however that the scripts only apply to conda prior to 23.7, so we don't have this problem at all for newer versions of conda