### PR TITLE
RFC: redact user-agent aau tokens in conda info

### DIFF
--- a/anaconda_anon_usage/patch.py
+++ b/anaconda_anon_usage/patch.py
@@ -45,6 +45,7 @@ def _patch_check_prefix():
     _debug("Applying anaconda_anon_usage cli.install patch")
 
     from conda.cli import install as cli_install
+
     Context._old_check_prefix = cli_install.check_prefix
     cli_install.check_prefix = _new_check_prefix
     context._aau_initialized = True
@@ -56,6 +57,7 @@ def _patch_conda_info():
     _debug("Applying anaconda_anon_usage conda info patch")
 
     from conda.cli import main_info
+
     Context._old_get_main_info_str = main_info.get_main_info_str
     main_info.get_main_info_str = _new_get_main_info_str
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def reset_patch(request):
         from conda.cli import install as cli_install
         from conda.cli import main_info
 
-        for k in ('___new_user_agent', '__user_agent', 'anaconda_anon_usage'):
+        for k in ("___new_user_agent", "__user_agent", "anaconda_anon_usage"):
             context._cache_.pop(k, None)
         context._aau_initialized = None
         if hasattr(Context, "anaconda_anon_usage"):

--- a/tests/unit/test_patch.py
+++ b/tests/unit/test_patch.py
@@ -1,4 +1,4 @@
-from conda.base.context import Context, context
+from conda.base.context import context
 
 from anaconda_anon_usage import patch
 
@@ -27,8 +27,9 @@ def test_main_already_patched():
 def test_main_info():
     patch.main(plugin=True)
     tokens = dict(t.split("/", 1) for t in context.user_agent.split(" "))
-    tokens["c"] = tokens["e"] = tokens["s"] = '.'
+    tokens["c"] = tokens["e"] = tokens["s"] = "."
     from conda.cli import main_info
+
     info_dict = main_info.get_info_dict(False)
     assert info_dict["user_agent"] == context.user_agent
     info_str = main_info.get_main_info_str(info_dict)


### PR DESCRIPTION
PRO: when users share their `conda info` information in Git issues and other public forums, their tokens are not revealed.
CON: we may want to modify our documentation that talks about viewing the token information by examining the `user-agent` line of `conda info`.

Because this doesn't affect `json` mode, you could see the tokens this way:
```
conda info --json | jq -r '.user_agent'    # or...
conda info --json | grep user_agent
```

Before:
```
 platform : osx-arm64
user-agent : conda/23.9.0 requests/2.31.0 CPython/3.11.4 Darwin/22.6.0 OSX/13.6 aau/0.4.3+4.g4b02f1d.dirty c/-HxvXt_4iIQAjp-Hvmez7w s/BCfC7xYzFUxwzKC0zgqJWQ e/KohVHi8sbiDBFMc3zCvBow
  UID:GID : 502:20
```
After:
```
 platform : osx-arm64
user-agent : conda/23.9.0 requests/2.31.0 CPython/3.11.4 Darwin/22.6.0 OSX/13.6 aau/0.4.3+4.g4b02f1d c/. s/. e/.
  UID:GID : 502:20
```
This redaction is applied only for the non-json version 