### PR TITLE
fix failing test due to conda changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,15 +34,13 @@ jobs:
       run: |
         source $CONDA/etc/profile.d/conda.sh
         conda install conda-build
-        conda build conda.recipe
+        conda build conda.recipe --no-test
         mv $CONDA/conda-bld .
-        # This ensures the noarch repodata.json is not clobbered
-        if [ -d conda-bld/win-64 ]; then rm -rf conda-bld/noarch; fi
     - name: Upload build artifacts
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
       with:
         if-no-files-found: error
-        name: conda-bld
+        name: cb-${{ matrix.os }}
         path: conda-bld/
   test:
     needs: build
@@ -63,22 +61,32 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:
         fetch-depth: 0
-    - name: Download build artfiacts
+    - name: Download build artfiacts (Unix)
+      if: matrix.os != 'windows-latest'
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
       with:
-        name: conda-bld
-        path: ./conda-bld
+        name: cb-ubuntu-latest
+        path: conda-bld
+    - name: Download build artfiacts (Windows)
+      if: matrix.os == 'windows-latest'
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+      with:
+        name: cb-windows-latest
+        path: conda-bld
     - name: Build test environments
       run: |
+        rm -rf $CONDA/conda-bld || :
         mv conda-bld $CONDA/
         source $CONDA/etc/profile.d/conda.sh
-        pkg=local::anaconda-anon-usage
-        conda install anaconda-client constructor conda-index $pkg
+        conda activate base
+        version=$(conda search local::anaconda-anon-usage | tail -1 | awk '{print $2}')
+        pkg="anaconda-anon-usage=$version"
+        conda install -c local -vvv anaconda-client constructor $pkg
         if [[ "${{ matrix.cversion }}" == 23.7.* ]]; then
           mamba=conda-libmamba-solver
           echo "MAMBA=yes" >> "$GITHUB_ENV"
         fi
-        conda create -p ./testenv $pkg conda==${{ matrix.cversion }} $mamba --file tests/requirements.txt
+        conda create -p ./testenv -c local $pkg conda==${{ matrix.cversion }} $mamba --file tests/requirements.txt
         if [ -f ./testenv/Scripts/conda.exe ]; then \
            sed -i.bak "s@CONDA_EXE=.*@CONDA_EXE=$PWD/testenv/Scripts/conda.exe@" testenv/etc/profile.d/conda.sh; \
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,11 +157,16 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Download package
+    - name: Download build artfiacts (Unix)
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
       with:
-        name: conda-bld
-        path: ./conda-bld
+        name: cb-ubuntu-latest
+        path: cb-unix
+    - name: Download build artfiacts (Windows)
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+      with:
+        name: cb-windows-latest
+        path: cb-win
     - name: Upload to anaconda.org
       if: github.event_name == 'push'
       env:
@@ -171,4 +176,4 @@ jobs:
         source $CONDA/bin/activate
         conda install anaconda-client
         [[ "$GITHUB_REF" =~ ^refs/tags/ ]] || export LABEL="--label dev"
-        anaconda --verbose --token $ANACONDA_TOKEN upload --user ctools $LABEL conda-bld/*/*.tar.bz2 --force
+        anaconda --verbose --token $ANACONDA_TOKEN upload --user ctools $LABEL cb-win/*/*.tar.bz2 cb-unix/*/*.tar.bz2 --force

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
         conda activate base
         version=$(conda search local::anaconda-anon-usage | tail -1 | awk '{print $2}')
         pkg="anaconda-anon-usage=$version"
-        conda install -c local -vvv anaconda-client constructor $pkg
+        conda install -c local anaconda-client constructor $pkg
         if [[ "${{ matrix.cversion }}" == 23.7.* ]]; then
           mamba=conda-libmamba-solver
           echo "MAMBA=yes" >> "$GITHUB_ENV"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        cversion: ['4.11.0', '4.14.0', '23.7.3', '23.5.2', '23.3.1', '23.1.0', '22.11.1']
+        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.3.1', '23.7.3', '23.10.0', '24.1.2']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Retrieve the source code

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - pip
   run:
     - python>=3.6
+    - __unix  # [not win]
+    - __win  # [win]
   run_constrained:
     - conda>=23.7  # [variant=="plugin"]
     - conda>=4.11,<23.7   # [variant=="patch"]

--- a/tests/unit/test_patch.py
+++ b/tests/unit/test_patch.py
@@ -30,7 +30,7 @@ def test_main_info():
     tokens["c"] = tokens["e"] = tokens["s"] = "."
     from conda.cli import main_info
 
-    info_dict = main_info.get_info_dict(False)
+    info_dict = main_info.get_info_dict()
     assert info_dict["user_agent"] == context.user_agent
     info_str = main_info.get_main_info_str(info_dict)
     ua_strs = [


### PR DESCRIPTION
- `get_info_dict` no longer takes an argument. We never needed to set it anyway, since we were passing its default value.
- our method for using verbose logging to confirm the use of our user agent string was broken. this one took a bit more effort to fix; but in short, we now need to be able to parse a dictionary embedded in the log.
- libmamba's treatment of the `local::` channel seems to be different
- added the most recent version of conda to the test matrix; pruned a couple of intermediate versions
- I've separated the windows and unix uploads because I'm aware that once Renovate updates us to v4 for the artifact actions, we'll need to do that. (Or block said upgrade). v4 of the artifact actions don't support merging uploads together.