### PR TITLE
DNM/RFC: shift .cloud/.org auth to .com

### DIFF
--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -4,6 +4,8 @@
 # conda must be avoided so that this package can be used in
 # child environments.
 
+import os
+import re
 import sys
 from collections import namedtuple
 from os.path import expanduser, join
@@ -89,3 +91,47 @@ def token_string(prefix=None, enabled=True):
     result = " ".join(parts)
     _debug("Full client token: %s", result)
     return result
+
+
+_token_value = None
+
+
+@cached
+def auth_string(url, enabled=True):
+    """
+    Returns the X-Auth header to send for the given URL. The purpose
+    is to indicate to repo.anaconda.com that the user is a registered
+    and logged-in member of anaconda.cloud. To that end, the auth
+    string will be non-empty only if all of the following are true:
+    - anaconda_anon_usage is enabled
+    - the request url is http[s]://*.anaconda.com
+    - the user has an installed token for anaconda.(cloud|org)
+    Furthermore, the patch code will apply this header only if there
+    is not an existing X-Auth header on the request.
+    """
+    global _token_value
+    if not enabled:
+        _debug("auth string disabled by config")
+        return
+    if 'anaconda.com' not in url:
+        _debug("auth string only sent to anaconda.com")
+        return
+    if not re.match(r'^https?://(?:[^/]*[.])?anaconda[.]com(?:/.*)?$', url):
+        _debug("auth string only sent to anaconda.com")
+        return
+    if _token_value is not None:
+        return _token_value
+    candidates = [(4, '')]
+    priorities = {'com': 1, 'cloud': 2, 'org': 3}
+    from conda.gateways import anaconda_client as ac
+    all_tokens = ac.read_binstar_tokens()
+    debug_token = os.environ.get('ANACONDA_ANON_USAGE_DEBUG_TOKEN')
+    if debug_token:
+        all_tokens['https://repo.anaconda.com/'] = debug_token
+    for t_url, t_val in all_tokens.items():
+        match = re.match(r'^https?://(?:[^/]*[.])?anaconda[.](cloud|com|org)(?:/.*)?$', t_url)
+        if match:
+            print(match.groups())
+            candidates.append((priorities.get(match.groups()[0], 5), t_val))
+    _token_value = min(candidates)[1]
+    return _token_value

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -42,9 +42,11 @@ test:
     - tests
   commands:
     - export ANACONDA_ANON_USAGE_DEBUG=1  # [unix]
+    - export ANACONDA_ANON_USAGE_DEBUG_TOKEN=test-auth-token  # [unix]
     - export PYTHONUNBUFFERED=1  # [unix]
     - set ANACONDA_ANON_USAGE_DEBUG=1  # [win]
-    - set PYTHONUNBUFFERED=1 # [win]
+    - set ANACONDA_ANON_USAGE_DEBUG_TOKEN=test-auth-token  # [win]
+    - set PYTHONUNBUFFERED=1  # [win]
     - conda create -n testchild1 --yes
     - conda create -n testchild2 --yes
     - conda info

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,3 +1,4 @@
+import os
 from os.path import exists
 
 from anaconda_anon_usage import tokens, utils
@@ -73,3 +74,24 @@ def test_token_string_env_readonly(monkeypatch):
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
+
+
+def test_auth_token():
+    test_key = 'ANACONDA_ANON_USAGE_DEBUG_TOKEN'
+    test_value = 'test-auth-token-unit'
+    old_value = os.environ.pop(test_key, None)
+    try:
+        os.environ[test_key] = test_value
+        url1 = 'https://repo.anaconda.com/pkgs/main/repodata.json'
+        url2 = 'https://conda.anaconda.org/anaconda'
+        url3 = 'https://someoneelsesrepo.com/packages'
+        assert tokens.auth_string(url1, True) == test_value
+        assert tokens.auth_string(url1, False) is None
+        assert tokens.auth_string(url2, True) is None
+        assert tokens.auth_string(url2, False) is None
+        assert tokens.auth_string(url3, True) is None
+        assert tokens.auth_string(url3, False) is None
+    finally:
+        os.environ.pop(test_key, None)
+        if old_value is not None:
+            os.environ[test_key] = old_value


### PR DESCRIPTION
The purpose of this PR is to implement a proposed modification that delivers a user's existing `anaconda.org` or `anaconda.cloud` token to `repo.anaconda.com` in an `X-Auth` header.