### PR TITLE
Fix macOS CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        # macos-13 defaults to osx-64, macos-14 defaults to osx-arm64
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
         cversion: ['4.11.0', '4.14.0', '22.11.1', '23.3.1', '23.7.3', '23.10.0', '24.1.2', '24.3.0']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,12 +46,13 @@ jobs:
       ANACONDA_ANON_USAGE_RAISE: 1
     defaults:
       run:
-        shell: bash
+        # https://github.com/conda-incubator/setup-miniconda#use-a-default-shell
+        shell: bash -el {0}  # bash exit immediately on error + login shell
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
-        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.3.1', '23.7.3', '23.10.0', '24.1.2']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.3.1', '23.7.3', '23.10.0', '24.1.2', '24.3.0']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Retrieve the source code
@@ -63,12 +64,16 @@ jobs:
       with:
         name: conda-bld
         path: conda-bld
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca
+      with:
+        miniconda-version: 'latest'
+        auto-activate-base: true
+        activate-environment: ""
     - name: Build test environments
       run: |
         rm -rf $CONDA/conda-bld || :
         mv conda-bld $CONDA/
-        source $CONDA/etc/profile.d/conda.sh
-        conda activate base
         version=$(conda search local::anaconda-anon-usage | tail -1 | awk '{print $2}')
         pkg="anaconda-anon-usage=$version"
         conda install -c local anaconda-client constructor $pkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         cversion: ['4.11.0', '4.14.0', '22.11.1', '23.3.1', '23.7.3', '23.10.0', '24.1.2']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,7 @@ jobs:
         miniconda-version: 'latest'
         auto-activate-base: true
         activate-environment: ""
+        conda-solver: classic
     - name: Build test environments
       run: |
         rm -rf $CONDA/conda-bld || :

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         name: conda-bld
         path: conda-bld
     - name: Setup Miniconda
-      uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca
+      uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
       with:
         miniconda-version: 'latest'
         auto-activate-base: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         cversion: ['4.11.0', '4.14.0', '22.11.1', '23.3.1', '23.7.3', '23.10.0', '24.1.2', '24.3.0']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
- Switch to macos-13 as a work-around for the new macos-latest not providing a default miniconda installation anymore
- add macOS on ARM64 testing
- add conda 24.3.0 to testing