### PR TITLE
Searching through deferred token writes list while fetching token.

### DIFF
--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -5,6 +5,7 @@ import os
 import sys
 from os.path import dirname, exists
 from threading import RLock
+from typing import List, Optional
 
 DPREFIX = os.environ.get("ANACONDA_ANON_USAGE_DEBUG_PREFIX") or ""
 DEBUG = bool(os.environ.get("ANACONDA_ANON_USAGE_DEBUG")) or DPREFIX
@@ -85,7 +86,7 @@ def _final_attempt():
     environment directory was not yet available.
     """
     global DEFERRED
-    for must_exist, fpath, token in DEFERRED:
+    for must_exist, fpath, token, what in DEFERRED:
         _write_attempt(must_exist, fpath, token)
 
 
@@ -123,6 +124,24 @@ def _write_attempt(must_exist, fpath, client_token, emulate_fail=False):
         return WRITE_FAIL
 
 
+def _deferred_exists(fpath: str, what: str, deferred_writes: List = DEFERRED) -> Optional[str]:
+    """
+    Check if the deferred token write exists in the DEFERRED write array.
+    If the path must already exist, this helper function determines if the token will be written in the future.
+
+    Args:
+        fpath: The file path to check for.
+        what: The type of token to check for.
+        deferred_tokens: The list of deferred tokens to check.
+
+    Returns:
+        The token if it exists, otherwise None.
+    """
+    for _, fp, token, what in deferred_writes:
+        if fp == fpath and what == what:
+            return token
+
+
 def _saved_token(fpath, what, must_exist=None):
     """
     Implements the saved token functionality. If the specified
@@ -131,6 +150,13 @@ def _saved_token(fpath, what, must_exist=None):
     this location. If that fails, return an empty string.
     """
     global DEFERRED
+
+    # If a deferred token exits for the given fpath, return it instead of generating a new one.
+    deferred_token = _deferred_exists(fpath, what)
+    if deferred_token:
+        _debug("Returning deferred %s token: %s", what, deferred_token)
+        return deferred_token
+
     client_token = ""
     _debug("%s token path: %s", what.capitalize(), fpath)
     if what[0] in READ_CHAOS:
@@ -155,5 +181,5 @@ def _saved_token(fpath, what, must_exist=None):
             # If the environment has not yet been created we need
             # to defer the token write until later.
             _debug("Deferring token write")
-            DEFERRED.append((must_exist, fpath, client_token))
+            DEFERRED.append((must_exist, fpath, client_token, what))
     return client_token

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -137,8 +137,8 @@ def _deferred_exists(fpath: str, what: str, deferred_writes: List = DEFERRED) ->
     Returns:
         The token if it exists, otherwise None.
     """
-    for _, fp, token, what in deferred_writes:
-        if fp == fpath and what == what:
+    for _, fp, token, w in deferred_writes:
+        if fp == fpath and w == what:
             return token
 
 

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -124,7 +124,9 @@ def _write_attempt(must_exist, fpath, client_token, emulate_fail=False):
         return WRITE_FAIL
 
 
-def _deferred_exists(fpath: str, what: str, deferred_writes: List = DEFERRED) -> Optional[str]:
+def _deferred_exists(
+    fpath: str, what: str, deferred_writes: List = DEFERRED
+) -> Optional[str]:
     """
     Check if the deferred token write exists in the DEFERRED write array.
     If the path must already exist, this helper function determines if the token will be written in the future.

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -129,7 +129,8 @@ def _deferred_exists(
 ) -> Optional[str]:
     """
     Check if the deferred token write exists in the DEFERRED write array.
-    If the path must already exist, this helper function determines if the token will be written in the future.
+    If the path must already exist, this helper function determines
+    if the token will be written in the future.
 
     Args:
         fpath: The file path to check for.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -87,3 +87,12 @@ def test_saved_token_existing_long(tmpdir):
     assert exists(token_path)
     assert token_saved == longer_token
     assert len(token_saved) == 23
+
+
+def test_return_deferred_token(tmpdir):
+    """Tests that utils_saved_token will return the token if it is in a deferred write state instead of creating a new one."""
+
+    token_path = tmpdir.join("aau_token")
+    token1 = utils._saved_token(token_path, "test", token_path)
+    token2 = utils._saved_token(token_path, "test", token_path)
+    assert token1 == token2

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -90,7 +90,10 @@ def test_saved_token_existing_long(tmpdir):
 
 
 def test_return_deferred_token(tmpdir):
-    """Tests that utils_saved_token will return the token if it is in a deferred write state instead of creating a new one."""
+    """
+    Tests that utils_saved_token will return the token
+    if it is in a deferred write state instead of creating a new one.
+    """
 
     token_path = tmpdir.join("aau_token")
     token1 = utils._saved_token(token_path, "test", token_path)


### PR DESCRIPTION
This PR searches through the DEFERRED list for tokens that will be written in _saved_token. If the token is found for the fpath and type of token, it is returned. For the anaconda-env-log plugin, we were experiencing an issue where calling anaconda_anon_usage/tokens.py in order to get the environment token, would return a different token than the one that anaconda-anon-usage would itself eventually write to disk. When logging environments, this would cause an environment to log twice with two different tokens.