### PR TITLE
DNMRFC: system token support, variant 1

### DIFF
--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -6,7 +6,8 @@
 
 import sys
 from collections import namedtuple
-from os.path import expanduser, abspath, join, exists, dirname
+from os.path import dirname, exists, expanduser, join
+
 from conda.base import constants as c_constants
 
 from . import __version__
@@ -38,20 +39,20 @@ def system_token():
         # Terminate the search at the first encounter
         # with a non-system directory, to ensure that
         # we use only system directories.
-        if path.startswith('~'):
+        if path.startswith("~"):
             break
         # Do not use the directories that involve
         # environment variables, or .d/ directories
-        if path.startswith('$') or path.endswith('/'):
+        if path.startswith("$") or path.endswith("/"):
             continue
         path = join(dirname(path), "aau_token")
         if exists(path):
             try:
                 _debug("Reading system token: %s", path)
-                with open(path, "r") as fp:
+                with open(path) as fp:
                     return fp.read()
-            except:
-                _debug("Unabled to read system token")
+            except Exception:
+                _debug("Unable to read system token")
                 return
     _debug("No system token found")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
+import tempfile
 from os import remove
 from os.path import join
 
 import pytest
-import tempfile
-from conda.base.context import Context, context
 from conda.base import constants as c_constants
+from conda.base.context import Context, context
 
 from anaconda_anon_usage import tokens, utils
 
@@ -17,11 +17,16 @@ def aau_token_path():
 @pytest.fixture
 def sys_token_path():
     with tempfile.TemporaryDirectory() as tname:
-        tname = tname.replace('\\', '/')
+        tname = tname.replace("\\", "/")
         o_path = c_constants.SEARCH_PATH
-        n_path = ('/tmp/fake/condarc.d/', tname + '/.condarc', tname + '/condarc', tname + '/condarc.d/')
+        n_path = (
+            "/tmp/fake/condarc.d/",
+            tname + "/.condarc",
+            tname + "/condarc",
+            tname + "/condarc.d/",
+        )
         c_constants.SEARCH_PATH = n_path + o_path
-        yield tname + '/aau_token'
+        yield tname + "/aau_token"
         c_constants.SEARCH_PATH = o_path
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ from os import remove
 from os.path import join
 
 import pytest
+import tempfile
 from conda.base.context import Context, context
+from conda.base import constants as c_constants
 
 from anaconda_anon_usage import tokens, utils
 
@@ -10,6 +12,17 @@ from anaconda_anon_usage import tokens, utils
 @pytest.fixture
 def aau_token_path():
     return join(tokens.CONFIG_DIR, "aau_token")
+
+
+@pytest.fixture
+def sys_token_path():
+    with tempfile.TemporaryDirectory() as tname:
+        tname = tname.replace('\\', '/')
+        o_path = c_constants.SEARCH_PATH
+        n_path = ('/tmp/fake/condarc.d/', tname + '/.condarc', tname + '/condarc', tname + '/condarc.d/')
+        c_constants.SEARCH_PATH = n_path + o_path
+        yield tname + '/aau_token'
+        c_constants.SEARCH_PATH = o_path
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -58,6 +58,7 @@ def test_token_string_disabled():
 def test_token_string_no_client_token(monkeypatch):
     def _mock_saved_token(*args, **kwargs):
         return ""
+
     monkeypatch.setattr(tokens, "environment_token", lambda prefix: "env_token")
     monkeypatch.setattr(tokens, "_saved_token", _mock_saved_token)
 


### PR DESCRIPTION
This addition allows `anaconda_anon_usage` to be used to help disaggregate usage from an organization while still preserving per-user anonymity.

To use it, an administrator would deposit a short token in a system location, presumably with MDM software.
- Unix: `/etc/conda/aau_token` or `/var/lib/conda/aau_token`
- Windows: `C:\ProgramData\conda\aau_token`

When the `client_token` is retrieved, it also retrieves this system token and ensures that the client token is _prefixed_ by the system token. The total token length is fixed at 22 characters; that hasn't changed. So for instance, if the organization token is 6 characters, the randomness is reduced to 16 characters. If for some reason the client token is tampered with or removed, or the system-installed prefix is changed, anaconda_anon_usage will re-generate it with the proper prefix.

If the system token is not present, as it will be in all normal scenarios, the full random token is generated instead. In fact, this code is _slightly_ more random than the previous implementation. 22 byte64 encoded characters can hold 16.5 bytes worth of randomness, but we were only generating 16 before; now we are generating 17.