### PR TITLE
Fully opt-in organization token support

### DIFF
--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -56,7 +56,7 @@ def system_token():
             try:
                 _debug("Reading system token: %s", path)
                 with open(path) as fp:
-                    return fp.read()
+                    return fp.read().strip()
             except Exception:
                 _debug("Unable to read system token")
                 return

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -16,6 +16,7 @@ from .utils import _debug, _random_token, _saved_token, cached
 
 Tokens = namedtuple("Tokens", ("version", "client", "session", "environment", "system"))
 CONFIG_DIR = expanduser("~/.conda")
+ORG_TOKEN_NAME = "org_token"
 
 
 @cached
@@ -49,7 +50,7 @@ def system_token():
             parts[0] = environ.get(parts[0][1:])
             if not parts[0]:
                 continue
-        parts[-1] = "org_token"
+        parts[-1] = ORG_TOKEN_NAME
         path = "/".join(parts)
         if isfile(path):
             try:

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -135,3 +135,7 @@ def token_string(prefix=None, enabled=True):
     result = " ".join(parts)
     _debug("Full client token: %s", result)
     return result
+
+
+if __name__ == "__main__":
+    print(token_string())

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -6,12 +6,15 @@
 
 import sys
 from collections import namedtuple
-from os.path import expanduser, join
+from os import environ
+from os.path import expanduser, isfile, join
+
+from conda.base import constants as c_constants
 
 from . import __version__
 from .utils import _debug, _random_token, _saved_token, cached
 
-Tokens = namedtuple("Tokens", ("version", "client", "session", "environment"))
+Tokens = namedtuple("Tokens", ("version", "client", "session", "environment", "system"))
 CONFIG_DIR = expanduser("~/.conda")
 
 
@@ -22,6 +25,41 @@ def version_token():
     version string itself.
     """
     return __version__
+
+
+@cached
+def system_token():
+    """
+    Returns the system/organization token. Unlike the other
+    tokens, it is desirable for this token to be stored in
+    a read-only/system location, presumably installed
+    The system/organization token can be stored anywhere
+    in the standard conda search path. Ideally, an MDM system
+    would place it in a read-only system location.
+    """
+    # Do not import SEARCH_PATH directly since we need to
+    # temporarily patch it for testing
+    for path in c_constants.SEARCH_PATH:
+        # Only consider directories where
+        # .condarc could also be found
+        if not path.endswith("/.condarc"):
+            continue
+        parts = path.split("/")
+        if parts[0].startswith("$"):
+            parts[0] = environ.get(parts[0][1:])
+            if not parts[0]:
+                continue
+        parts[-1] = "org_token"
+        path = "/".join(parts)
+        if isfile(path):
+            try:
+                _debug("Reading system token: %s", path)
+                with open(path) as fp:
+                    return fp.read()
+            except Exception:
+                _debug("Unable to read system token")
+                return
+    _debug("No system token found")
 
 
 @cached
@@ -65,7 +103,11 @@ def all_tokens(prefix=None):
     Fields: version, client, session, environment
     """
     return Tokens(
-        version_token(), client_token(), session_token(), environment_token(prefix)
+        version_token(),
+        client_token(),
+        session_token(),
+        environment_token(prefix),
+        system_token(),
     )
 
 
@@ -76,7 +118,9 @@ def token_string(prefix=None, enabled=True):
     appended to the conda user agent.
     """
     parts = ["aau/" + __version__]
-    if enabled:
+    if enabled or system_token():
+        if not enabled:
+            _debug("anaconda_anon_usage enabled by system token")
         values = all_tokens(prefix)
         if values.client:
             parts.append("c/" + values.client)
@@ -84,6 +128,8 @@ def token_string(prefix=None, enabled=True):
             parts.append("s/" + values.session)
         if values.environment:
             parts.append("e/" + values.environment)
+        if values.system:
+            parts.append("o/" + values.system)
     else:
         _debug("anaconda_anon_usage disabled by config")
     result = " ".join(parts)

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -119,9 +119,7 @@ def token_string(prefix=None, enabled=True):
     appended to the conda user agent.
     """
     parts = ["aau/" + __version__]
-    if enabled or system_token():
-        if not enabled:
-            _debug("anaconda_anon_usage enabled by system token")
+    if enabled:
         values = all_tokens(prefix)
         if values.client:
             parts.append("c/" + values.client)

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -151,7 +151,7 @@ def _deferred_exists(
             return token
 
 
-def _saved_token(fpath, what, must_exist=None, read_only=False):
+def _saved_token(fpath, what, must_exist=None):
     """
     Implements the saved token functionality. If the specified
     file exists, and contains a token with the right format,
@@ -178,9 +178,6 @@ def _saved_token(fpath, what, must_exist=None, read_only=False):
             _debug("Retrieved %s token: %s", what, client_token)
         except Exception as exc:
             _debug("Unexpected error reading: %s\n  %s", fpath, exc, error=True)
-    if not client_token and read_only:
-        _debug("Read-only %s token does not exist", what)
-        return client_token
     if len(client_token) < 22:
         if len(client_token) > 0:
             _debug("Generating longer %s token", what)

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -35,10 +35,6 @@ WRITE_SUCCESS = 0
 WRITE_DEFER = 1
 WRITE_FAIL = 2
 
-# Length of the randomly generated token. There is 6 bits of
-# randomness in each character.
-TOKEN_LENGTH = 22
-
 
 def cached(func):
     def call_if_needed(*args, **kwargs):
@@ -77,10 +73,8 @@ def _debug(s, *args, error=False):
 
 
 def _random_token(what="random"):
-    # base64 encoding captures 6 bits per character.
-    # Generate enough random bytes to ensure all charaaters are random
-    data = os.urandom((TOKEN_LENGTH * 6 - 1) // 8 + 1)
-    result = base64.urlsafe_b64encode(data).decode("ascii")[:TOKEN_LENGTH]
+    data = os.urandom(16)
+    result = base64.urlsafe_b64encode(data).strip(b"=").decode("ascii")
     _debug("Generated %s token: %s", what, result)
     return result
 

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -35,6 +35,10 @@ WRITE_SUCCESS = 0
 WRITE_DEFER = 1
 WRITE_FAIL = 2
 
+# Length of the randomly generated token. There is 6 bits of
+# randomness in each character.
+TOKEN_LENGTH = 22
+
 
 def cached(func):
     def call_if_needed(*args, **kwargs):
@@ -73,8 +77,10 @@ def _debug(s, *args, error=False):
 
 
 def _random_token(what="random"):
-    data = os.urandom(16)
-    result = base64.urlsafe_b64encode(data).strip(b"=").decode("ascii")
+    # base64 encoding captures 6 bits per character.
+    # Generate enough random bytes to ensure all charaaters are random
+    data = os.urandom((TOKEN_LENGTH * 6 - 1) // 8 + 1)
+    result = base64.urlsafe_b64encode(data).decode("ascii")[:TOKEN_LENGTH]
     _debug("Generated %s token: %s", what, result)
     return result
 
@@ -145,7 +151,7 @@ def _deferred_exists(
             return token
 
 
-def _saved_token(fpath, what, must_exist=None):
+def _saved_token(fpath, what, must_exist=None, read_only=False):
     """
     Implements the saved token functionality. If the specified
     file exists, and contains a token with the right format,
@@ -172,9 +178,12 @@ def _saved_token(fpath, what, must_exist=None):
             _debug("Retrieved %s token: %s", what, client_token)
         except Exception as exc:
             _debug("Unexpected error reading: %s\n  %s", fpath, exc, error=True)
+    if not client_token and read_only:
+        _debug("Read-only %s token does not exist", what)
+        return client_token
     if len(client_token) < 22:
         if len(client_token) > 0:
-            _debug("Generating longer token")
+            _debug("Generating longer %s token", what)
         client_token = _random_token(what)
         status = _write_attempt(must_exist, fpath, client_token, what[0] in WRITE_CHAOS)
         if status == WRITE_FAIL:
@@ -183,6 +192,6 @@ def _saved_token(fpath, what, must_exist=None):
         elif status == WRITE_DEFER:
             # If the environment has not yet been created we need
             # to defer the token write until later.
-            _debug("Deferring token write")
+            _debug("Deferring %s token write", what)
             DEFERRED.append((must_exist, fpath, client_token, what))
     return client_token

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
+import tempfile
 from os import remove
 from os.path import join
 
 import pytest
+from conda.base import constants as c_constants
 from conda.base.context import Context, context
 
 from anaconda_anon_usage import tokens, utils
@@ -10,6 +12,25 @@ from anaconda_anon_usage import tokens, utils
 @pytest.fixture
 def aau_token_path():
     return join(tokens.CONFIG_DIR, "aau_token")
+
+
+@pytest.fixture
+def system_token():
+    with tempfile.TemporaryDirectory() as tname:
+        tname = tname.replace("\\", "/")
+        o_path = c_constants.SEARCH_PATH
+        n_path = (
+            "/tmp/fake/condarc.d/",
+            tname + "/.condarc",
+            tname + "/condarc",
+            tname + "/condarc.d/",
+        )
+        c_constants.SEARCH_PATH = n_path + o_path
+        rtoken = utils._random_token()
+        with open(tname + "/org_token", "w") as fp:
+            fp.write(rtoken)
+        yield rtoken
+        c_constants.SEARCH_PATH = o_path
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -42,11 +42,6 @@ def test_token_string_with_system(system_token):
     assert "o/" + system_token in token_string
 
 
-def test_token_string_disabled_override_system(system_token):
-    token_string = tokens.token_string(enabled=False)
-    assert "o/" + system_token in token_string
-
-
 def test_token_string_no_client_token(monkeypatch, system_token):
     def _mock_saved_token(*args, **kwargs):
         return ""

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -25,6 +25,7 @@ def test_token_string():
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" in token_string
+    assert "o/" not in token_string
 
 
 def test_token_string_disabled():
@@ -33,39 +34,54 @@ def test_token_string_disabled():
     assert "c/" not in token_string
     assert "s/" not in token_string
     assert "e/" not in token_string
+    assert "o/" not in token_string
 
 
-def test_token_string_no_client_token(monkeypatch):
+def test_token_string_with_system(system_token):
+    token_string = tokens.token_string()
+    assert "o/" + system_token in token_string
+
+
+def test_token_string_disabled_override_system(system_token):
+    token_string = tokens.token_string(enabled=False)
+    assert "o/" + system_token in token_string
+
+
+def test_token_string_no_client_token(monkeypatch, system_token):
+    def _mock_saved_token(*args, **kwargs):
+        return ""
+
     monkeypatch.setattr(tokens, "environment_token", lambda prefix: "env_token")
-    monkeypatch.setattr(tokens, "_saved_token", lambda fpath, what: "")
+    monkeypatch.setattr(tokens, "_saved_token", _mock_saved_token)
 
     token_string = tokens.token_string()
     assert "c/" not in token_string
     assert "s/" in token_string
     assert "e/env_token" in token_string
+    assert "o/" + system_token in token_string
 
 
-def test_token_string_no_environment_token(
-    monkeypatch,
-):
+def test_token_string_no_environment_token(monkeypatch, system_token):
     monkeypatch.setattr(tokens, "environment_token", lambda prefix: "")
 
     token_string = tokens.token_string()
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
+    assert "o/" + system_token in token_string
 
 
-def test_token_string_full_readonly(monkeypatch):
+def test_token_string_full_readonly(monkeypatch, system_token):
     monkeypatch.setattr(utils, "READ_CHAOS", "ce")
     monkeypatch.setattr(utils, "WRITE_CHAOS", "ce")
     token_string = tokens.token_string()
     assert "c/" not in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
+    assert "o/" + system_token in token_string
 
 
-def test_token_string_env_readonly(monkeypatch):
+def test_token_string_env_readonly(monkeypatch, system_token):
     monkeypatch.setattr(utils, "READ_CHAOS", "e")
     monkeypatch.setattr(utils, "WRITE_CHAOS", "e")
 
@@ -73,3 +89,4 @@ def test_token_string_env_readonly(monkeypatch):
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
+    assert "o/" + system_token in token_string


### PR DESCRIPTION
This addition allows `anaconda_anon_usage` to be used to help disaggregate usage from an organization while still preserving per-user anonymity. This is a 100% opt-in option that requires explicit action by someone with system administrator privileges. 

To use it, an administrator would deposit a short token in a system location, presumably with MDM software.
- Unix: `/etc/conda/org_token` or `/var/lib/conda/org_token`
- Windows: `C:\ProgramData\conda\org_token`

If this token is present, it overrides the `anaconda_anon_usage: disable` option, and it adds as an additional token to the user agent, prefixed by "o/"; e.g.

```
conda/24.9.2 requests/2.31.0 CPython/3.12.3 Darwin/23.6.0 OSX/14.7.1 solver/libmamba conda-libmamba-solver/24.1.0 libmambapy/1.5.8 aau/0.4.4 c/ajvwtgobUyzBuGWQufY00B s/1ZgH7Vyy_1AR3ph8AH2CIg e/BbZF49u-mQBZmbIG9jiRBA o/V3X8_3UEWQhu1t4ZUD8IDg
```

Placing this token in a system location accomplishes multiple goals.

- First, this is something that requires administrator privileges to install. Normal users will not write there; in particular, this package will not write the token there.
- Similarly, it cannot be deliberately or accidentally removed by a non-admin user, which is something that could happen if it is installed in a user directory.
- It can be installed _without having conda installed_, where it remains unused unless Anaconda is installed. This should simplify the integration of the token into a laptop provisioning program.