### PR TITLE
make new info patch

### DIFF
--- a/anaconda_anon_usage/patch.py
+++ b/anaconda_anon_usage/patch.py
@@ -68,8 +68,14 @@ def _patch_conda_info():
 
     from conda.cli import main_info
 
-    Context._old_get_main_info_str = main_info.get_main_info_str
-    main_info.get_main_info_str = _new_get_main_info_str
+    if hasattr(main_info, "get_main_info_display"):
+        Context._old_get_main_info_str = main_info.get_main_info_display
+        main_info.get_main_info_display = _new_get_main_info_str
+    elif hasattr(main_info, "get_main_info_str"):
+        Context._old_get_main_info_str = main_info.get_main_info_str
+        main_info.get_main_info_str = _new_get_main_info_str
+    else:
+        _debug("Cannot apply anaconda_anon_usage conda info patch")
 
 
 def main(plugin=False):


### PR DESCRIPTION
Newer versions of conda have moved the `conda info` string logic into the method `get_main_info_display` from `get_main_info_str` in the module `conda.cli.main_info`.

Without this fix, token values are printed to the screen during `conda info`, instead of being redacted like we intended.