### PR TITLE
Add anaconda token if anaconda_cloud_auth is available

### DIFF
--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -7,6 +7,7 @@
 import base64
 import json
 import sys
+import time
 import uuid
 from collections import namedtuple
 from os import environ
@@ -16,7 +17,8 @@ from . import __version__
 from .utils import _debug, _random_token, _saved_token, cached
 
 Tokens = namedtuple(
-    "Tokens", ("version", "client", "session", "environment", "anaconda", "system")
+    "Tokens",
+    ("version", "client", "session", "environment", "anaconda_cloud", "system"),
 )
 CONFIG_DIR = expanduser("~/.conda")
 ORG_TOKEN_NAME = "org_token"
@@ -81,7 +83,9 @@ def system_token():
             try:
                 _debug("Reading system token: %s", path)
                 with open(path) as fp:
-                    return fp.read().strip()
+                    token = fp.read().strip()
+                    _debug("Retrieved system token: %s", token)
+                    return token
             except Exception:
                 _debug("Unable to read system token")
                 return
@@ -123,28 +127,47 @@ def environment_token(prefix=None):
 
 
 @cached
-def anaconda_token():
+def anaconda_cloud_token():
     """
     Returns the token for the logged-in anaconda user, if present.
     """
+    candidates = []
+
+    def _process(data):
+        data = json.loads(base64.b64decode(data))["api_key"]
+        data = json.loads(base64.b64decode(data.split(".", 2)[1] + "==="))
+        candidates.append((data["exp"], data["sub"]))
+
     try:
-        from anaconda_cloud_auth.config import AnacondaCloudConfig
+        import keyring
 
-        cfg = AnacondaCloudConfig()
-        if not cfg.api_key:
-            from anaconda_cloud_auth.token import TokenInfo
-
-            cfg = TokenInfo.load(domain=cfg.domain)
-            if not cfg.api_key:
-                return
-        info = cfg.api_key.split(".", 2)[1] + "==="
-        sub = json.loads(base64.b64decode(info))["sub"]
-        token = base64.urlsafe_b64encode(uuid.UUID(sub).bytes)
-        return token.decode("ascii").rstrip("=")
+        data = keyring.get_password("Anaconda Cloud", "anaconda.cloud")
+        if data:
+            _debug("Reading Anaconda Cloud token in system keyring")
+            _process(data)
     except ImportError:
-        _debug("anaconda_cloud_auth not installed in this environment")
+        pass
     except Exception as exc:
-        _debug("unexpected error obtaining anaconda token: %s", exc)
+        _debug("Unexpected error reading keyring data:", exc)
+    fpath = expanduser(join("~", ".anaconda", "keyring"))
+    if isfile(fpath):
+        _debug("Reading Anaconda Cloud token in keyring file")
+        try:
+            with open(fpath, "rb") as fp:
+                data = fp.read()
+            data = json.loads(data)["Anaconda Cloud"]["anaconda.cloud"]
+            _process(data)
+        except Exception as exc:
+            _debug("Unexpected error reading keyring file: %s", exc)
+    if candidates:
+        token = sorted(candidates)[-1]
+        if time.time() > token[0]:
+            _debug("Anaconda Cloud Token has expired")
+        else:
+            token = uuid.UUID(token[1]).bytes
+            token = base64.urlsafe_b64encode(token).decode("ascii").strip("=")
+            _debug("Retrieved Anaconda Cloud token: %s", token)
+            return token
 
 
 @cached
@@ -158,7 +181,7 @@ def all_tokens(prefix=None):
         client_token(),
         session_token(),
         environment_token(prefix),
-        anaconda_token(),
+        anaconda_cloud_token(),
         system_token(),
     )
 
@@ -178,8 +201,8 @@ def token_string(prefix=None, enabled=True):
             parts.append("s/" + values.session)
         if values.environment:
             parts.append("e/" + values.environment)
-        if values.anaconda:
-            parts.append("a/" + values.anaconda)
+        if values.anaconda_cloud:
+            parts.append("a/" + values.anaconda_cloud)
         if values.system:
             parts.append("o/" + values.system)
     else:


### PR DESCRIPTION
This code adds a new `a/...` token for those users that are authenticated to anaconda cloud using the `anaconda-cloud-auth` package. This has no impact for any users who are not logged in to our services.

Example token string:
```
aau/0.5.0+5.g73de726 c/xt_egSegDH-5NxiiJaDrKo s/wfHTi7l0-TuzB2jzQfrXky e/BbZF49u-mQBZmbIG9jiRBA a/6NxsCXJLQ-uoMUBAZmGsTQ o/kA1VeQZ5QJq0EPqi6AwV8A
```