### PR TITLE
walk back keyring usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         # 23.7.0 : first plugin-based variant, but conda info --envs --json is broken
         # 23.9.0 : last variant with the classic default solver
         # 23.10.0 : first variant with the libmamba default solver
-        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.5.2', '23.7.1', '23.9.0', '23.10.0', '24.9.2']
+        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.5.2', '23.7.1', '23.9.0', '23.10.0', '24.11.3', '25.1.0']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Retrieve the source code
@@ -78,6 +78,7 @@ jobs:
         conda-solver: classic
     - name: Build test environments
       run: |
+        conda config --add channels defaults
         rm -rf $CONDA/conda-bld || :
         mv conda-bld $CONDA/
         version=$(conda search local::anaconda-anon-usage | tail -1 | awk '{print $2}')
@@ -88,6 +89,9 @@ jobs:
           echo "MAMBA=yes" >> "$GITHUB_ENV"
         fi
         conda create -p ./testenv -c local $pkg conda==${{ matrix.cversion }} $mamba --file tests/requirements.txt
+        mkdir -p ./testenv/envs
+        conda create -p ./testenv/envs/testchild1 python --yes
+        conda create -p ./testenv/envs/testchild2 python --yes
         if [ -f ./testenv/Scripts/conda.exe ]; then \
            sed -i.bak "s@CONDA_EXE=.*@CONDA_EXE=$PWD/testenv/Scripts/conda.exe@" testenv/etc/profile.d/conda.sh; \
         fi
@@ -99,8 +103,6 @@ jobs:
         conda info 1>output.txt 2>&1 | type output.txt
         find "Error loading" output.txt >nul
         if %errorlevel% equ 0 exit -1
-        conda create -n testchild1 --yes
-        conda create -n testchild2 --yes
         python tests\integration\test_config.py
         if "%MAMBA%" equ "yes" (
           conda config --set solver libmamba

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         # 23.7.0 : first plugin-based variant, but conda info --envs --json is broken
         # 23.9.0 : last variant with the classic default solver
         # 23.10.0 : first variant with the libmamba default solver
-        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.5.2', '23.7.1', '23.9.0', '23.10.0', '24.11.3', '25.1.0']
+        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.5.2', '23.7.1', '23.9.0', '23.10.0', '24.11.3', '25.1.1']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Retrieve the source code

--- a/anaconda_anon_usage/patch.py
+++ b/anaconda_anon_usage/patch.py
@@ -1,5 +1,5 @@
 # This module implements the changes to conda's context class
-# needed to deploy the additional anonmyous user data. It pulls
+# needed to deploy the additional anonymous user data. It pulls
 # the token management functions themselves from the api module.
 
 import re


### PR DESCRIPTION
```
$ python -m anaconda_anon_usage.tokens
aau/0.5.0+20.gdb2b5ae c/xt_egSegDH-5NxiiJaDrKo s/OUDFGtrMCdw_pdR86zcxHq e/BbZF49u-mQBZmbIG9jiRBA a/6NxsCXJLQ-uoMUBAZmGsTQ o/kA1VeQZ5QJq0EPqi6AwV8B
```

We need to make sure we don't use the keyring library here. Otherwise, when a different install of python is _reading_ a keyring than the one that _created_ it, we get an unavoidable popup. Alas, there's no easy way to work around or even gracefully fail if we are in non-interactive mode

While I was at it I added testing against conda 25