### PR TITLE
Support a new admin-installed machine token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,9 +104,11 @@ jobs:
         find "Error loading" output.txt >nul
         if %errorlevel% equ 0 exit -1
         python tests\integration\test_config.py
+        if %errorlevel% neq 0 exit -1
         if "%MAMBA%" equ "yes" (
           conda config --set solver libmamba
           python tests\integration\test_config.py
+          if %errorlevel% neq 0 exit -1
           conda config --set solver classic
         )
     - name: Test code (Windows)

--- a/anaconda_anon_usage/patch.py
+++ b/anaconda_anon_usage/patch.py
@@ -8,7 +8,7 @@ import sys
 from conda.auxlib.decorators import memoizedproperty
 from conda.base.context import Context, ParameterLoader, PrimitiveParameter, context
 
-from .tokens import system_token, token_string
+from .tokens import has_admin_tokens, token_string
 from .utils import _debug
 
 
@@ -25,7 +25,7 @@ def _new_user_agent(ctx):
         # configuration by installing an organization token. The
         # effect is similar to placing "anaconda_anon_usage: true"
         # in /etc/conda/.condarc.
-        is_enabled = context.anaconda_anon_usage or system_token()
+        is_enabled = context.anaconda_anon_usage or has_admin_tokens()
         if is_enabled and not context.anaconda_anon_usage:
             _debug("system token overriding the config setting")
         token = token_string(prefix, is_enabled)

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -11,17 +11,26 @@ import time
 import uuid
 from collections import namedtuple
 from os import environ
-from os.path import expanduser, isfile, join
+from os.path import expanduser, isdir, isfile, join
 
 from . import __version__
 from .utils import _debug, _random_token, _saved_token, cached
 
 Tokens = namedtuple(
     "Tokens",
-    ("version", "client", "session", "environment", "anaconda_cloud", "system"),
+    (
+        "version",
+        "client",
+        "session",
+        "environment",
+        "anaconda_cloud",
+        "organization",
+        "machine",
+    ),
 )
 CONFIG_DIR = expanduser("~/.conda")
 ORG_TOKEN_NAME = "org_token"
+MACHINE_TOKEN_NAME = "machine_token"
 
 
 @cached
@@ -34,14 +43,9 @@ def version_token():
 
 
 @cached
-def system_token():
+def _search_path():
     """
-    Returns the system/organization token. Unlike the other
-    tokens, it is desirable for this token to be stored in
-    a read-only/system location, presumably installed
-    The system/organization token can be stored anywhere
-    in the standard conda search path. Ideally, an MDM system
-    would place it in a read-only system location.
+    Returns the search path for system tokens.
     """
     try:
         # Do not import SEARCH_PATH directly since we need to
@@ -67,29 +71,68 @@ def system_token():
             "~/.condarc",
             "$CONDARC",
         )
+    result = []
+    home = expanduser("~")
     for path in search_path:
         # Only consider directories where
         # .condarc could also be found
         if not path.endswith("/.condarc"):
             continue
-        parts = path.split("/")
-        if parts[0].startswith("$"):
+        parts = path.split("/")[:-1]
+        if parts[0] == "~":
+            parts[0] = home
+        elif parts[0].startswith("$"):
             parts[0] = environ.get(parts[0][1:])
             if not parts[0]:
                 continue
-        parts[-1] = ORG_TOKEN_NAME
         path = "/".join(parts)
-        if isfile(path):
-            try:
-                _debug("Reading system token: %s", path)
-                with open(path) as fp:
-                    token = fp.read().strip()
-                    _debug("Retrieved system token: %s", token)
-                    return token
-            except Exception:
-                _debug("Unable to read system token")
-                return
-    _debug("No system token found")
+        if isdir(path) and path != home:
+            result.append(path)
+    return result
+
+
+def _system_token(fname, what):
+    """
+    Returns an organization or machine token installed somewhere
+    in the conda path. Unlike most tokens, these will typically
+    be installed by system administrators, often by mobile device
+    management software. There can also be multiple tokens present
+    along the path, in which case we combine them
+    """
+    tokens = []
+    for path in _search_path():
+        fpath = join(path, fname)
+        if not isfile(fpath):
+            continue
+        try:
+            _debug("Reading %s token: %s", what, fpath)
+            with open(fpath) as fp:
+                token = fp.read().strip()
+                _debug("Retrieved %s token: %s", what, token)
+                if token not in tokens:
+                    tokens.append(token)
+        except Exception as exc:
+            _debug("Unable to read %s token: %s", what, exc)
+            return
+    if tokens:
+        return "/".join(tokens)
+    _debug("No %s tokens found", what)
+
+
+@cached
+def organization_token():
+    """
+    Returns the organization token.
+    """
+    return _system_token(ORG_TOKEN_NAME, "organization")
+
+
+@cached
+def machine_token():
+    """
+    Returns the machine token.
+    """
+    return _system_token(MACHINE_TOKEN_NAME, "machine")
 
 
 @cached
@@ -170,7 +213,8 @@ def all_tokens(prefix=None):
         session_token(),
         environment_token(prefix),
         anaconda_cloud_token(),
-        system_token(),
+        organization_token(),
+        machine_token(),
     )
 
 
@@ -191,8 +235,10 @@ def token_string(prefix=None, enabled=True):
             parts.append("e/" + values.environment)
         if values.anaconda_cloud:
             parts.append("a/" + values.anaconda_cloud)
-        if values.system:
-            parts.append("o/" + values.system)
+        if values.organization:
+            parts.append("o/" + values.organization)
+        if values.machine:
+            parts.append("m/" + values.machine)
     else:
         _debug("anaconda_anon_usage disabled by config")
     result = " ".join(parts)
@@ -201,4 +247,7 @@ def token_string(prefix=None, enabled=True):
 
 
 if __name__ == "__main__":
-    print(token_string())
+    if "--random" in sys.argv:
+        print(_random_token())
+    else:
+        print(token_string())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def aau_token_path():
 
 
 @pytest.fixture
-def system_token():
+def system_tokens():
     with tempfile.TemporaryDirectory() as tname:
         tname = tname.replace("\\", "/")
         o_path = c_constants.SEARCH_PATH
@@ -26,10 +26,13 @@ def system_token():
             tname + "/condarc.d/",
         )
         c_constants.SEARCH_PATH = n_path + o_path
-        rtoken = utils._random_token()
+        otoken = utils._random_token()
+        mtoken = utils._random_token()
         with open(tname + "/org_token", "w") as fp:
-            fp.write(rtoken)
-        yield rtoken
+            fp.write(otoken)
+        with open(tname + "/machine_token", "w") as fp:
+            fp.write(mtoken)
+        yield (otoken, mtoken)
         c_constants.SEARCH_PATH = o_path
 
 

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from os.path import basename, expanduser, isfile, join
 
-from anaconda_anon_usage.tokens import system_token
+from anaconda_anon_usage import tokens as m_tokens
 
 nfailed = 0
 
@@ -40,16 +40,18 @@ def _config(value, ctype):
     subprocess.run(["conda", "config", "--set", KEY, cvalue], capture_output=True)
     if ctype == "env" or value == "default":
         subprocess.run(["conda", "config", "--remove-key", KEY], capture_output=True)
-    return value in yes_modes or system_token()
+    return value in yes_modes or m_tokens.has_admin_tokens()
 
 
 all_modes = ["true", "false", "yes", "no", "on", "off", "default"]
 yes_modes = ("true", "yes", "on", "default")
 all_tokens = {"aau", "c", "s", "e"}
 aau_only = {"aau"}
-if isfile("/etc/conda/org_token") or isfile("C:/ProgramData/conda/org_token"):
+if m_tokens.organization_token():
     all_tokens.add("o")
-if isfile(join(expanduser("~"), ".anaconda", "keyring")):
+if m_tokens.machine_token():
+    all_tokens.add("m")
+if m_tokens.anaconda_cloud_token():
     all_tokens.add("a")
 
 proc = subprocess.run(

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -26,6 +26,7 @@ def test_token_string():
     assert "s/" in token_string
     assert "e/" in token_string
     assert "o/" not in token_string
+    assert "m/" not in token_string
 
 
 def test_token_string_disabled():
@@ -35,14 +36,17 @@ def test_token_string_disabled():
     assert "s/" not in token_string
     assert "e/" not in token_string
     assert "o/" not in token_string
+    assert "m/" not in token_string
 
 
-def test_token_string_with_system(system_token):
+def test_token_string_with_system(system_tokens):
+    org_token, mch_token = system_tokens
     token_string = tokens.token_string()
-    assert "o/" + system_token in token_string
+    assert "o/" + org_token in token_string
+    assert "m/" + mch_token in token_string
 
 
-def test_token_string_no_client_token(monkeypatch, system_token):
+def test_token_string_no_client_token(monkeypatch, system_tokens):
     def _mock_saved_token(*args, **kwargs):
         return ""
 
@@ -50,38 +54,46 @@ def test_token_string_no_client_token(monkeypatch, system_token):
     monkeypatch.setattr(tokens, "_saved_token", _mock_saved_token)
 
     token_string = tokens.token_string()
+    org_token, mch_token = system_tokens
     assert "c/" not in token_string
     assert "s/" in token_string
     assert "e/env_token" in token_string
-    assert "o/" + system_token in token_string
+    assert "o/" + org_token in token_string
+    assert "m/" + mch_token in token_string
 
 
-def test_token_string_no_environment_token(monkeypatch, system_token):
+def test_token_string_no_environment_token(monkeypatch, system_tokens):
     monkeypatch.setattr(tokens, "environment_token", lambda prefix: "")
 
     token_string = tokens.token_string()
+    org_token, mch_token = system_tokens
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
-    assert "o/" + system_token in token_string
+    assert "o/" + org_token in token_string
+    assert "m/" + mch_token in token_string
 
 
-def test_token_string_full_readonly(monkeypatch, system_token):
+def test_token_string_full_readonly(monkeypatch, system_tokens):
     monkeypatch.setattr(utils, "READ_CHAOS", "ce")
     monkeypatch.setattr(utils, "WRITE_CHAOS", "ce")
     token_string = tokens.token_string()
+    org_token, mch_token = system_tokens
     assert "c/" not in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
-    assert "o/" + system_token in token_string
+    assert "o/" + org_token in token_string
+    assert "m/" + mch_token in token_string
 
 
-def test_token_string_env_readonly(monkeypatch, system_token):
+def test_token_string_env_readonly(monkeypatch, system_tokens):
     monkeypatch.setattr(utils, "READ_CHAOS", "e")
     monkeypatch.setattr(utils, "WRITE_CHAOS", "e")
 
     token_string = tokens.token_string()
+    org_token, mch_token = system_tokens
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
-    assert "o/" + system_token in token_string
+    assert "o/" + org_token in token_string
+    assert "m/" + mch_token in token_string


### PR DESCRIPTION
The organization token is working great for our Gateway work, but we realized that yet another admin-installed token would be worthwhile: a _machine_ token. This would be a random token, generated once per machine and placed right alongside `org_token`, to allow anonymous disaggregation at the machine level.

This is similar to a client token, but differences arise in a multi-user case. Given a machine with five users, there will be five different client tokens, but only one hostname. Since hostname is not anonymous, generating a random machine token will enable us to better detect these multi-user scenarios.

Obviously this is not something that can be installed without admin privileges so this has no way of affecting ordinary user scenarios—and that is deliberate! This is enabled only in customer settings with an explicit motion.