### PR TITLE
Opt-in heartbeat support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,6 +111,9 @@ jobs:
           if %errorlevel% neq 0 exit -1
           conda config --set solver classic
         )
+        if "${{ matrix.cversion }}" equ "25.1.0" (
+          python tests\integration\test_heartbeats.py
+        )
     - name: Test code (Windows)
       if: matrix.os == 'windows-latest'
       shell: cmd
@@ -128,6 +131,9 @@ jobs:
           conda config --set solver libmamba
           python tests/integration/test_config.py
           conda config --set solver classic
+        fi
+        if [[ ${{ matrix.cversion }} = 25.* ]]; then
+          python tests/integration/test_heartbeats.py
         fi
     - name: Test code (Unix)
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,68 +78,50 @@ jobs:
         conda-solver: classic
     - name: Build test environments
       run: |
+        source $CONDA/etc/profile.d/conda.sh
         conda config --add channels defaults
+        conda activate base
         rm -rf $CONDA/conda-bld || :
         mv conda-bld $CONDA/
         version=$(conda search local::anaconda-anon-usage | tail -1 | awk '{print $2}')
         pkg="anaconda-anon-usage=$version"
         conda install -c local anaconda-client constructor $pkg
-        if [[ "${{ matrix.cversion }}" == 23.7.* ]]; then
-          mamba=conda-libmamba-solver
-          echo "MAMBA=yes" >> "$GITHUB_ENV"
-        fi
-        conda create -p ./testenv -c local $pkg conda==${{ matrix.cversion }} $mamba --file tests/requirements.txt
+        conda create -p ./testenv -c local $pkg conda==${{ matrix.cversion }} --file tests/requirements.txt
         mkdir -p ./testenv/envs
         conda create -p ./testenv/envs/testchild1 python --yes
         conda create -p ./testenv/envs/testchild2 python --yes
         if [ -f ./testenv/Scripts/conda.exe ]; then \
            sed -i.bak "s@CONDA_EXE=.*@CONDA_EXE=$PWD/testenv/Scripts/conda.exe@" testenv/etc/profile.d/conda.sh; \
         fi
-    - name: Test environments (Windows)
-      if: matrix.os == 'windows-latest'
-      shell: cmd
+    - name: Test code
       run: |
-        call testenv\Scripts\activate
-        conda info 1>output.txt 2>&1 | type output.txt
-        find "Error loading" output.txt >nul
-        if %errorlevel% equ 0 exit -1
-        python tests\integration\test_config.py
-        if %errorlevel% neq 0 exit -1
-        if "%MAMBA%" equ "yes" (
-          conda config --set solver libmamba
-          python tests\integration\test_config.py
-          if %errorlevel% neq 0 exit -1
-          conda config --set solver classic
-        )
-        if "${{ matrix.cversion }}" equ "25.1.0" (
-          python tests\integration\test_heartbeats.py
-        )
-    - name: Test code (Windows)
-      if: matrix.os == 'windows-latest'
-      shell: cmd
-      run: |
-        call testenv\Scripts\activate
-        pytest
-    - name: Test environments (Unix)
-      if: matrix.os != 'windows-latest'
-      run: |
-        source ./testenv/bin/activate
+        source testenv/etc/profile.d/conda.sh
+        conda activate base
         conda info 2>&1 | tee output.txt
         if grep -q 'Error loading' output.txt; then exit -1; fi
+        pytest
         python tests/integration/test_config.py
-        if [ "$MAMBA" = "yes" ]; then
-          conda config --set solver libmamba
-          python tests/integration/test_config.py
-          conda config --set solver classic
-        fi
-        if [[ ${{ matrix.cversion }} = 25.* ]]; then
-          python tests/integration/test_heartbeats.py
-        fi
-    - name: Test code (Unix)
-      if: matrix.os != 'windows-latest'
+    - name: Test heartbeats (pwsh)
+      if: matrix.os == 'windows-latest' && (matrix.cversion == '24.11.3' || matrix.cversion == '25.1.1')
+      shell: pwsh
+      run: |
+        .\testenv\shell\condabin\conda-hook.ps1
+        conda activate base
+        python tests\integration\test_heartbeats.py powershell
+    - name: Test heartbeats (cmd)
+      if: matrix.os == 'windows-latest' && (matrix.cversion == '24.11.3' || matrix.cversion == '25.1.1')
+      shell: cmd
+      run: |
+        call .\testenv\Scripts\activate.bat
+        if %errorlevel% neq 0 exit 1
+        python tests\integration\test_heartbeats.py cmd.exe
+        if %errorlevel% neq 0 exit 1
+    - name: Test heartbeats (bash)
+      if: matrix.os != 'windows-latest' && (matrix.cversion == '24.11.3' || matrix.cversion == '25.1.1')
       run: |
         source ./testenv/bin/activate
-        pytest
+        conda info
+        python tests/integration/test_heartbeats.py posix
     - name: Build an installer
       run: |
         cd tests/integration
@@ -149,6 +131,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: cmd
       run: |
+        source $CONDA/bin/activate
         cd tests/integration
         start /wait AIDTest-1.0-Windows-x86_64.exe /S /D=%USERPROFILE%\aidtest
         call %USERPROFILE%\aidtest\Scripts\activate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,6 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        args: [--write]
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.31.1
     hooks:

--- a/anaconda_anon_usage/heartbeat.py
+++ b/anaconda_anon_usage/heartbeat.py
@@ -1,0 +1,116 @@
+"""
+This module implements a heartbeat function that sends a simple
+HEAD request to an upstream repository. It can be configured to
+trigger upon environment activation, but it is off by default.
+The intended use case is for organizations to enable it through
+system configuration for better usage tracking.
+"""
+
+import argparse
+import os
+import sys
+from threading import Thread
+
+from conda.base.context import context
+from conda.gateways.connection.session import CondaSession
+from conda.models.channel import Channel
+
+from . import utils
+
+VERBOSE = False
+STANDALONE = False
+DRY_RUN = os.environ.get("ANACONDA_HEARTBEAT_DRY_RUN")
+
+CLD_REPO = "https://repo.anaconda.cloud"
+ORG_REPO = "https://conda.anaconda.org"
+COM_REPO = "https://repo.anaconda.com/pkgs"
+HEARTBEAT_PATH = "/noarch/activate-0.0.0-0.conda"
+
+
+def _print(msg, *args, standalone=False, error=False):
+    global VERBOSE
+    global STANDALONE
+    if not (VERBOSE or utils.DEBUG or error):
+        return
+    if standalone and not STANDALONE:
+        return
+    # It is very important that these messages are printed to stderr
+    # when called from within the activate script. Otherwise they
+    # will insert themselves into the activation command set
+    ofile = sys.stdout if STANDALONE and not (error or utils.DEBUG) else sys.stderr
+    print(msg % args, file=ofile)
+
+
+def _ping(session, url, wait):
+    try:
+        response = session.head(url, proxies=session.proxies)
+        _print("Status code (expect 404): %s", response.status_code)
+    except Exception as exc:
+        if type(exc).__name__ != "ConnectionError":
+            _print("Heartbeat error: %s", exc, error=True)
+
+
+def attempt_heartbeat(channel=None, path=None, wait=False):
+    global DRY_RUN
+    line = "------------------------"
+    _print(line, standalone=True)
+    _print("anaconda-ident heartbeat", standalone=True)
+    _print(line, standalone=True)
+
+    if not hasattr(context, "_aau_initialized"):
+        from . import patch
+
+        patch.main()
+
+    if channel and "/" in channel:
+        url = channel
+    else:
+        # Silences the defaults deprecation error
+        if not context._channels:
+            context._channels = ["defaults"]
+        urls = [u for c in context.channels for u in Channel(c).urls()]
+        urls.extend(u.rstrip("/") for u in context.channel_alias.urls())
+        if any(u.startswith(CLD_REPO) for u in urls):
+            base = CLD_REPO
+        elif any(u.startswith(COM_REPO) for u in urls):
+            base = COM_REPO
+        elif any(u.startswith(ORG_REPO) for u in urls):
+            base = ORG_REPO
+        else:
+            _print("No valid heartbeat channel")
+            _print(line, standalone=True)
+            return
+        url = base + "/" + (channel or "main")
+    url = url.rstrip("/") + "/" + (path or HEARTBEAT_PATH).lstrip("/")
+
+    _print("Heartbeat url: %s", url)
+    _print("User agent: %s", context.user_agent)
+    if DRY_RUN:
+        _print("Dry run selected, not sending heartbeat.")
+    else:
+        session = CondaSession()
+        t = Thread(target=_ping, args=(session, url, wait), daemon=True)
+        t.start()
+        _print("%saiting for response", "W" if wait else "Not w")
+        t.join(timeout=None if wait else 0.1)
+    _print(line, standalone=True)
+
+
+def main():
+    global VERBOSE
+    global DRY_RUN
+    p = argparse.ArgumentParser()
+    p.add_argument("--channel", default=None)
+    p.add_argument("--path", default=None)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--verbose", action="store_true")
+    p.add_argument("--wait", action="store_true")
+    args = p.parse_args()
+    VERBOSE = args.verbose
+    DRY_RUN = args.dry_run
+    attempt_heartbeat(args.channel, args.path, args.wait)
+
+
+if __name__ == "__main__":
+    STANDALONE = True
+    main()

--- a/anaconda_anon_usage/patch.py
+++ b/anaconda_anon_usage/patch.py
@@ -15,7 +15,7 @@ from conda.base.context import (
     locate_prefix_by_name,
 )
 
-from .tokens import has_admin_tokens, token_string
+from .tokens import token_string
 from .utils import _debug
 
 
@@ -25,17 +25,7 @@ def _new_user_agent(ctx):
         getattr(Context, "checked_prefix", None) or context.target_prefix or sys.prefix
     )
     try:
-        # If an organization token exists, it overrides the value of
-        # context.anaconda_anon_usage. For most users, this has no
-        # effect. But this does provide a system administrator the
-        # ability to enable telemetry without modifying a user's
-        # configuration by installing an organization token. The
-        # effect is similar to placing "anaconda_anon_usage: true"
-        # in /etc/conda/.condarc.
-        is_enabled = context.anaconda_anon_usage or has_admin_tokens()
-        if is_enabled and not context.anaconda_anon_usage:
-            _debug("system token overriding the config setting")
-        token = token_string(prefix, is_enabled)
+        token = token_string(prefix, context.anaconda_anon_usage)
         if token:
             result += " " + token
     except Exception:  # pragma: nocover

--- a/anaconda_anon_usage/patch.py
+++ b/anaconda_anon_usage/patch.py
@@ -2,11 +2,18 @@
 # needed to deploy the additional anonymous user data. It pulls
 # the token management functions themselves from the api module.
 
+import os
 import re
 import sys
 
 from conda.auxlib.decorators import memoizedproperty
-from conda.base.context import Context, ParameterLoader, PrimitiveParameter, context
+from conda.base.context import (
+    Context,
+    ParameterLoader,
+    PrimitiveParameter,
+    context,
+    locate_prefix_by_name,
+)
 
 from .tokens import has_admin_tokens, token_string
 from .utils import _debug
@@ -49,6 +56,23 @@ def _new_get_main_info_str(info_dict):
     return Context._old_get_main_info_str(info_dict)
 
 
+def _new_activate(self):
+    if not context.anaconda_heartbeat:
+        return self._old_activate()
+    try:
+        from .heartbeat import attempt_heartbeat
+
+        env = self.env_name_or_prefix
+        if env and os.sep not in env:
+            env = locate_prefix_by_name(env)
+        Context.checked_prefix = env or sys.prefix
+        attempt_heartbeat()
+    except Exception as exc:
+        _debug("Failed to attempt heartbeat: %s", exc, error=True)
+    finally:
+        return self._old_activate()
+
+
 def _patch_check_prefix():
     if hasattr(Context, "_old_check_prefix"):
         return
@@ -78,24 +102,43 @@ def _patch_conda_info():
         _debug("Cannot apply anaconda_anon_usage conda info patch")
 
 
-def main(plugin=False):
+def _patch_activate():
+    _debug("Applying anaconda_anon_usage activate patch")
+    from conda import activate
+
+    if hasattr(activate, "_Activator"):
+        _Activator = activate._Activator
+        if hasattr(_Activator, "activate"):
+            _Activator._old_activate = _Activator.activate
+            _Activator.activate = _new_activate
+            return
+    _debug("Cannot apply anaconda_anon_usage activate patch")
+
+
+def main(plugin=False, command=None):
     if getattr(context, "_aau_initialized", None) is not None:
         _debug("anaconda_anon_usage already active")
         return False
     _debug("Applying anaconda_anon_usage context patch")
 
     # conda.base.context.Context.user_agent
-    # Adds the ident token to the user agent string
+    # Adds the ident tokens to the user agent string
     Context._old_user_agent = Context.user_agent
     # Using a different name ensures that this is stored
     # in the cache in a different place than the original
     Context.user_agent = memoizedproperty(_new_user_agent)
 
-    # conda.base.context.Context
-    # Adds anaconda_anon_usage as a managed string config parameter
+    # conda.base.context.Context.anaconda_anon_usage
+    # Adds the anaconda_anon_usage toggle, defaulting to true
     _param = ParameterLoader(PrimitiveParameter(True))
     Context.anaconda_anon_usage = _param
     Context.parameter_names += (_param._set_name("anaconda_anon_usage"),)
+
+    # conda.base.context.Context
+    # Adds the anaconda_heartbeat toggle, defaulting to false
+    _param = ParameterLoader(PrimitiveParameter(False))
+    Context.anaconda_heartbeat = _param
+    Context.parameter_names += (_param._set_name("anaconda_heartbeat"),)
 
     # conda.base.context.checked_prefix
     # Saves the prefix used in a conda install command
@@ -109,7 +152,10 @@ def main(plugin=False):
         # The pre-command plugin avoids the circular import
         # of conda.cli.install, so we can apply the patch now
         _patch_conda_info()
-        _patch_check_prefix()
+        if command == "activate":
+            _patch_activate()
+        if command == "info":
+            _patch_check_prefix()
     else:
         # We need to delay further. Schedule the patch for the
         # next time context.__init__ is called.

--- a/anaconda_anon_usage/plugin.py
+++ b/anaconda_anon_usage/plugin.py
@@ -5,7 +5,7 @@ def pre_command_patcher(command):
     try:
         from . import patch  # noqa
 
-        patch.main(plugin=True)
+        patch.main(plugin=True, command=command)
     except Exception as exc:  # pragma: nocover
         print("Error loading anaconda-anon-usage:", exc)
 
@@ -23,5 +23,6 @@ def conda_pre_commands():
             "uninstall",
             "env_create",
             "search",
+            "activate",
         },  # which else?
     )

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -14,7 +14,7 @@ from os import environ
 from os.path import expanduser, isdir, isfile, join
 
 from . import __version__
-from .utils import _debug, _random_token, _saved_token, cached
+from .utils import _debug, _random_token, _read_file, _saved_token, cached
 
 Tokens = namedtuple(
     "Tokens",
@@ -104,7 +104,7 @@ def _system_token(fname, what):
         fpath = join(path, fname)
         if not isfile(fpath):
             continue
-        t_tokens = _saved_token(fpath, what, read_only=True)
+        t_tokens = _read_file(fpath, what + "token")
         if t_tokens:
             for token in t_tokens.split("/"):
                 if token not in tokens:
@@ -170,14 +170,8 @@ def anaconda_cloud_token():
     Returns the token for the logged-in anaconda user, if present.
     """
     fpath = expanduser(join("~", ".anaconda", "keyring"))
-    if not isfile(fpath):
-        return
-    _debug("Reading Anaconda Cloud token in keyring file")
-    try:
-        with open(fpath, "rb") as fp:
-            data = fp.read()
-    except Exception as exc:
-        _debug("Unexpected error reading keyring file: %s", exc)
+    data = _read_file(fpath, "anaconda keyring")
+    if not data:
         return
     try:
         data = json.loads(data)["Anaconda Cloud"]["anaconda.cloud"]
@@ -237,7 +231,7 @@ def token_string(prefix=None, enabled=True):
     else:
         _debug("anaconda_anon_usage disabled by config")
     result = " ".join(parts)
-    _debug("Full client token: %s", result)
+    _debug("Full aau token string: %s", result)
     return result
 
 

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -107,37 +107,30 @@ def _system_token(fname, what, find_only=False):
         if find_only:
             _debug("Found %s token: %s", what, fpath)
             return True
-        try:
-            _debug("Reading %s token: %s", what, fpath)
-            with open(fpath) as fp:
-                t_tokens = fp.read().strip()
-                if t_tokens:
-                    _debug("Retrieved %s token: %s", what, t_tokens)
-                    for token in t_tokens.split("/"):
-                        if token not in tokens:
-                            tokens.append(token)
-        except Exception as exc:
-            _debug("Unable to read %s token: %s", what, exc)
-            return
+        t_tokens = _saved_token(fpath, what)
+        if t_tokens:
+            for token in t_tokens.split("/"):
+                if token not in tokens:
+                    tokens.append(token)
     if tokens:
         return "/".join(tokens)
     _debug("No %s tokens found", what)
 
 
 @cached
-def organization_token():
+def organization_token(find_only=False):
     """
     Returns the organization token.
     """
-    return _system_token(ORG_TOKEN_NAME, "organization")
+    return _system_token(ORG_TOKEN_NAME, "organization", find_only)
 
 
 @cached
-def machine_token():
+def machine_token(find_only=False):
     """
     Returns the machine token.
     """
-    return _system_token(MACHINE_TOKEN_NAME, "machine")
+    return _system_token(MACHINE_TOKEN_NAME, "machine", find_only)
 
 
 @cached
@@ -146,9 +139,7 @@ def has_admin_tokens():
     Returns true of either a machine or org token is installed.
     Used to trigger an override of the anaconda_anon_usage setting.
     """
-    return _system_token(ORG_TOKEN_NAME, "organization", True) or _system_token(
-        MACHINE_TOKEN_NAME, "machine", True
-    )
+    return organization_token(True) or machine_token(True)
 
 
 @cached

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -91,7 +91,7 @@ def _search_path():
     return result
 
 
-def _system_token(fname, what, find_only=False):
+def _system_token(fname, what):
     """
     Returns an organization or machine token installed somewhere
     in the conda path. Unlike most tokens, these will typically
@@ -104,9 +104,6 @@ def _system_token(fname, what, find_only=False):
         fpath = join(path, fname)
         if not isfile(fpath):
             continue
-        if find_only:
-            _debug("Found %s token: %s", what, fpath)
-            return True
         t_tokens = _saved_token(fpath, what, read_only=True)
         if t_tokens:
             for token in t_tokens.split("/"):
@@ -118,28 +115,19 @@ def _system_token(fname, what, find_only=False):
 
 
 @cached
-def organization_token(find_only=False):
+def organization_token():
     """
     Returns the organization token.
     """
-    return _system_token(ORG_TOKEN_NAME, "organization", find_only)
+    return _system_token(ORG_TOKEN_NAME, "organization")
 
 
 @cached
-def machine_token(find_only=False):
+def machine_token():
     """
     Returns the machine token.
     """
-    return _system_token(MACHINE_TOKEN_NAME, "machine", find_only)
-
-
-@cached
-def has_admin_tokens():
-    """
-    Returns true of either a machine or org token is installed.
-    Used to trigger an override of the anaconda_anon_usage setting.
-    """
-    return organization_token(True) or machine_token(True)
+    return _system_token(MACHINE_TOKEN_NAME, "machine")
 
 
 @cached

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -107,7 +107,7 @@ def _system_token(fname, what, find_only=False):
         if find_only:
             _debug("Found %s token: %s", what, fpath)
             return True
-        t_tokens = _saved_token(fpath, what)
+        t_tokens = _saved_token(fpath, what, read_only=True)
         if t_tokens:
             for token in t_tokens.split("/"):
                 if token not in tokens:

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -153,7 +153,7 @@ def _deferred_exists(
             return token
 
 
-def _saved_token(fpath, what, must_exist=None):
+def _saved_token(fpath, what, must_exist=None, read_only=False):
     """
     Implements the saved token functionality. If the specified
     file exists, and contains a token with the right format,
@@ -180,7 +180,7 @@ def _saved_token(fpath, what, must_exist=None):
             _debug("Retrieved %s token: %s", what, client_token)
         except Exception as exc:
             _debug("Unexpected error reading: %s\n  %s", fpath, exc, error=True)
-    if len(client_token) < TOKEN_LENGTH:
+    if not read_only and len(client_token) < TOKEN_LENGTH:
         if len(client_token) > 0:
             _debug("Generating longer %s token", what)
         client_token = _random_token(what)

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -3,7 +3,7 @@ import base64
 import errno
 import os
 import sys
-from os.path import dirname, exists
+from os.path import dirname, isdir, isfile
 from threading import RLock
 from typing import List, Optional
 
@@ -109,7 +109,7 @@ def _write_attempt(must_exist, fpath, client_token, emulate_fail=False):
     Attempt to write the token to the given location.
     Return True with success, False otherwise.
     """
-    if must_exist and not exists(must_exist):
+    if must_exist and not isdir(must_exist):
         _debug("Directory not ready: %s", must_exist)
         return WRITE_DEFER
     try:
@@ -156,7 +156,7 @@ def _deferred_exists(
             return token
 
 
-def _saved_token(fpath, what, must_exist=None, read_only=False):
+def _read_file(fpath, what, must_exist=None, read_only=False):
     """
     Implements the saved token functionality. If the specified
     file exists, and contains a token with the right format,
@@ -168,32 +168,48 @@ def _saved_token(fpath, what, must_exist=None, read_only=False):
     # If a deferred token exits for the given fpath, return it instead of generating a new one.
     deferred_token = _deferred_exists(fpath, what)
     if deferred_token:
-        _debug("Returning deferred %s token: %s", what, deferred_token)
+        _debug("Returning deferred %s: %s", what, deferred_token)
         return deferred_token
 
-    client_token = ""
-    _debug("%s token path: %s", what.capitalize(), fpath)
+    _debug("%s path: %s", what.capitalize(), fpath)
     if what[0] in READ_CHAOS:
-        _debug("Pretending %s token is not present", what)
-    elif exists(fpath):
+        _debug("Pretending %s is not present", what)
+    elif not isfile(fpath):
+        _debug("%s file is not present", what)
+    else:
         try:
             # Use just the first line of the file, if it exists
             with open(fpath) as fp:
-                client_token = "".join(fp.read().splitlines()[:1])
-            _debug("Retrieved %s token: %s", what, client_token)
+                data = fp.read()
+            _debug("Retrieved %s: %s", what, data)
+            return data
         except Exception as exc:
             _debug("Unexpected error reading: %s\n  %s", fpath, exc, error=True)
+
+
+def _saved_token(fpath, what, must_exist=None, read_only=False):
+    """
+    Implements the saved token functionality. If the specified
+    file exists, and contains a token with the right format,
+    return it. Otherwise, generate a new one and save it in
+    this location. If that fails, return an empty string.
+    """
+    global DEFERRED
+    what = what + " token"
+    client_token = _read_file(fpath, what) or ""
+    # Just use the first line of the file
+    client_token = "".join(client_token.splitlines()[:1])
     if not read_only and len(client_token) < TOKEN_LENGTH:
         if len(client_token) > 0:
-            _debug("Generating longer %s token", what)
+            _debug("Generating longer %s", what)
         client_token = _random_token(what)
         status = _write_attempt(must_exist, fpath, client_token, what[0] in WRITE_CHAOS)
         if status == WRITE_FAIL:
-            _debug("Returning blank %s token", what)
+            _debug("Returning blank %s", what)
             return ""
         elif status == WRITE_DEFER:
             # If the environment has not yet been created we need
             # to defer the token write until later.
-            _debug("Deferring %s token write", what)
+            _debug("Deferring %s write", what)
             DEFERRED.append((must_exist, fpath, client_token, what))
     return client_token

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -58,9 +58,12 @@ def cached(func):
     return call_if_needed
 
 
-def _cache_clear():
+def _cache_clear(*args):
     global CACHE
-    CACHE.clear()
+    if not args:
+        CACHE.clear()
+    else:
+        CACHE = {k: v for k, v in CACHE.items() if k[0] not in args}
 
 
 def _debug(s, *args, error=False):

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -40,7 +40,7 @@ def _config(value, ctype):
     subprocess.run(["conda", "config", "--set", KEY, cvalue], capture_output=True)
     if ctype == "env" or value == "default":
         subprocess.run(["conda", "config", "--remove-key", KEY], capture_output=True)
-    return value in yes_modes or m_tokens.has_admin_tokens()
+    return value in yes_modes
 
 
 all_modes = ["true", "false", "yes", "no", "on", "off", "default"]

--- a/tests/integration/test_heartbeats.py
+++ b/tests/integration/test_heartbeats.py
@@ -56,7 +56,7 @@ def verify_user_agent(output, expected, envname=None, marker=None):
     other_tokens["n"] = envname if envname else "base"
 
     user_agent = ""
-    marker = marker or "User-Agent"
+    marker = marker or "[uU]ser.[aA]gent"  # codespell:ignore
     MATCH_RE = r".*" + marker + r'(["\']?): *(["\']?)(.+)'
     for v in output.splitlines():
         match = re.match(MATCH_RE, v)
@@ -155,9 +155,7 @@ for hval in ("true", "false"):
             elif hval == "false" and (no_hb_url or hb_urls):
                 status = "NOT DISABLED"
             if hb_urls and not status:
-                status, header = verify_user_agent(
-                    proc.stderr, expected, envname, "Full client token"
-                )
+                status, header = verify_user_agent(proc.stderr, expected, envname)
             if need_header:
                 if header:
                     print("|", header)

--- a/tests/integration/test_heartbeats.py
+++ b/tests/integration/test_heartbeats.py
@@ -100,6 +100,11 @@ def verify_user_agent(output, expected, envname=None, marker=None):
     return ", ".join(status), header
 
 
+if len(sys.argv) > 1:
+    shells = sys.argv[1:]
+else:
+    shells = ["posix", "cmd.exe", "powershell"]
+shells = shells + shells
 print("Testing heartbeat")
 print("-----------------")
 urls = [u for c in context.channels for u in Channel(c).urls()]
@@ -122,14 +127,7 @@ for hval in ("true", "false"):
     for envname in envs:
         # Do each one twice to make sure the user agent string
         # remains correct on repeated attempts
-        for stype in (
-            "posix",
-            "posix",
-            "cmd.exe",
-            "cmd.exe",
-            "powershell",
-            "powershell",
-        ):
+        for stype in shells:
             cmd = ["conda", "shell." + stype, "activate", envname]
             proc = subprocess.run(
                 cmd,

--- a/tests/integration/test_heartbeats.py
+++ b/tests/integration/test_heartbeats.py
@@ -1,0 +1,180 @@
+import json
+import os
+import re
+import subprocess
+import sys
+
+from conda.base.context import context
+from conda.models.channel import Channel
+
+from anaconda_anon_usage import __version__ as aau_version
+from anaconda_anon_usage import patch
+
+patch.main()
+context.__init__()
+expected = ("aau", "c", "s", "e")
+can_disable = True
+if os.path.isfile("/etc/conda/org_token"):
+    expected += ("o",)
+if os.path.isfile("/etc/conda/machine_token"):
+    expected += ("m",)
+
+os.environ["ANACONDA_ANON_USAGE_DEBUG"] = "1"
+os.environ["ANACONDA_HEARTBEAT_DRY_RUN"] = "1"
+
+ALL_FIELDS = {"aau", "aid", "c", "s", "e", "u", "h", "n", "m", "o", "U", "H", "N"}
+
+
+def get_test_envs():
+    proc = subprocess.run(
+        ["conda", "info", "--envs", "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    pfx_s = os.path.join(sys.prefix, "envs") + os.sep
+    pdata = json.loads(proc.stdout)
+    # Limit ourselves to two non-base environments to speed up local testing
+    envs = [sys.prefix] + [e for e in pdata["envs"] if e.startswith(pfx_s)][:2]
+    envs = {("base" if e == sys.prefix else os.path.basename(e)): e for e in envs}
+    return envs
+
+
+envs = get_test_envs()
+maxlen = max(len(e) for e in envs)
+nfailed = 0
+other_tokens = {"aau": aau_version}
+all_session_tokens = set()
+all_environments = set()
+
+
+def verify_user_agent(output, expected, envname=None, marker=None):
+    # Unfortunately conda has evolved how it logs request headers
+    # So this regular expression attempts to match multiple forms
+    # > User-Agent: conda/...
+    # .... {'User-Agent': 'conda/...', ...}
+    other_tokens["n"] = envname if envname else "base"
+
+    user_agent = ""
+    marker = marker or "User-Agent"
+    MATCH_RE = r".*" + marker + r'(["\']?): *(["\']?)(.+)'
+    for v in output.splitlines():
+        match = re.match(MATCH_RE, v)
+        if match:
+            _, delim, user_agent = match.groups()
+            if delim and delim in user_agent:
+                user_agent = user_agent.split(delim, 1)[0]
+            break
+
+    new_values = [t.split("/", 1) for t in user_agent.split(" ") if "/" in t]
+    new_values = {k: v for k, v in new_values if k in ALL_FIELDS}
+    header = " ".join(f"{k}/{v}" for k, v in new_values.items())
+
+    # Confirm that all of the expected tokens are present
+    status = []
+    missing = set(expected) - set(new_values)
+    extras = set(new_values) - set(expected)
+    if missing:
+        status.append(f"{','.join(missing)} MISSING")
+    if extras:
+        status.append(f"{','.join(extras)} EXTRA")
+    modified = []
+    duplicated = []
+    for k, v in new_values.items():
+        if k == "s":
+            if new_values["s"] in all_session_tokens:
+                status.append("SESSION")
+            all_session_tokens.add(new_values["s"])
+            continue
+        if k == "e":
+            k = "e/" + (envname or "base")
+            if k not in other_tokens and v in all_environments:
+                duplicated.append("e")
+            all_environments.add(v)
+        if other_tokens.setdefault(k, v) != v:
+            modified.append(k)
+    if duplicated:
+        status.append(f"DUPLICATED: {','.join(duplicated)}")
+    if modified:
+        status.append(f"MODIFIED: {','.join(modified)}")
+    return ", ".join(status), header
+
+
+print("Testing heartbeat")
+print("-----------------")
+urls = [u for c in context.channels for u in Channel(c).urls()]
+urls.extend(u.rstrip("/") for u in context.channel_alias.urls())
+if any(".anaconda.cloud" in u for u in urls):
+    hb_url = "https://repo.anaconda.cloud/"
+elif any(".anaconda.com" in u for u in urls):
+    hb_url = "https://repo.anaconda.com/"
+elif any(".anaconda.org" in u for u in urls):
+    hb_url = "https://conda.anaconda.org/"
+else:
+    hb_url = None
+if hb_url:
+    hb_url += "pkgs/main/noarch/activate-0.0.0-0.conda"
+print("Expected heartbeat url:", hb_url)
+print("Expected user agent tokens:", ",".join(expected))
+need_header = True
+for hval in ("true", "false"):
+    os.environ["CONDA_ANACONDA_HEARTBEAT"] = hval
+    for envname in envs:
+        # Do each one twice to make sure the user agent string
+        # remains correct on repeated attempts
+        for stype in (
+            "posix",
+            "posix",
+            "cmd.exe",
+            "cmd.exe",
+            "powershell",
+            "powershell",
+        ):
+            cmd = ["conda", "shell." + stype, "activate", envname]
+            proc = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            header = status = ""
+            no_hb_url = "No valid heartbeat channel" in proc.stderr
+            hb_urls = {
+                line.rsplit(" ", 1)[-1]
+                for line in proc.stderr.splitlines()
+                if "Heartbeat url:" in line
+            }
+            status = ""
+            if hval == "true":
+                if not (no_hb_url or hb_urls):
+                    status = "NOT ENABLED"
+                elif hb_url and not hb_urls:
+                    status = "NO HEARTBEAT URL"
+                elif not hb_url and hb_urls:
+                    status = "UNEXPECTED URLS: " + ",".join(hb_urls)
+                elif hb_url and any(hb_url not in u for u in hb_urls):
+                    status = "INCORRECT URLS: " + ",".join(hb_urls)
+            elif hval == "false" and (no_hb_url or hb_urls):
+                status = "NOT DISABLED"
+            if hb_urls and not status:
+                status, header = verify_user_agent(
+                    proc.stderr, expected, envname, "Full client token"
+                )
+            if need_header:
+                if header:
+                    print("|", header)
+                print(f"hval  shell      {'envname':{maxlen}} status")
+                print(f"----- ---------- {'-' * maxlen} ----------")
+                need_header = False
+            print(f"{hval:5} {stype:10} {envname:{maxlen}} {status or 'OK'}")
+            if status:
+                print("|", " ".join(cmd))
+                for line in proc.stderr.splitlines():
+                    if line.strip():
+                        print("!", line)
+                if header:
+                    print("|", header)
+                nfailed += 1
+
+print("FAILURES:", nfailed)
+sys.exit(nfailed)

--- a/tests/unit/test_patch.py
+++ b/tests/unit/test_patch.py
@@ -1,20 +1,50 @@
 from conda.base.context import context
 
-from anaconda_anon_usage import patch
+from anaconda_anon_usage import patch, tokens
+
+BASIC = {"aau", "c", "s", "e"}
+SYSTEM = {"o", "m"}
+OPTIONAL = {"a"} | SYSTEM
+ALL = BASIC | OPTIONAL
 
 
-def test_new_user_agent():
+def _assert_has_expected_tokens(must=BASIC, mustnot=()):
     patch.main(plugin=True)
     assert context.user_agent is not None
-    for term in ["conda/", "aau/", "e/", "c/", "s/"]:
-        assert term in context.user_agent
+    tokens = {
+        tok.split("/", 1)[0] for tok in context.user_agent.split(" ") if "/" in tok
+    }
+    mustnot = set(mustnot)
+    must = ({"conda"} | BASIC | set(must)) - mustnot
+    missing = must - tokens
+    extras = tokens & mustnot
+    assert not missing, "MISSING: %s" % missing
+    assert not extras, "EXTRAS: %s" % extras
+
+
+def test_user_agent_basic_tokens():
+    _assert_has_expected_tokens()
+
+
+def test_user_agent_no_system_tokens(no_system_tokens):
+    _assert_has_expected_tokens(mustnot=SYSTEM)
+
+
+def test_user_agent_system_tokens(system_tokens):
+    _assert_has_expected_tokens(must=SYSTEM)
+
+
+def test_user_agent_local_tokens():
+    token_names = ("anaconda_cloud", "organization", "machine")
+    expected = [
+        tname[0] for tname in token_names if getattr(tokens, tname + "_token")()
+    ]
+    _assert_has_expected_tokens(expected)
 
 
 def test_user_agent_no_token(monkeypatch):
     monkeypatch.setattr(patch, "token_string", lambda prefix: "")
-    patch.main(plugin=True)
-    assert "conda/" in context.user_agent
-    assert "aau/" not in context.user_agent
+    _assert_has_expected_tokens(mustnot=ALL)
 
 
 def test_main_already_patched():
@@ -27,7 +57,9 @@ def test_main_already_patched():
 def test_main_info():
     patch.main(plugin=True)
     tokens = dict(t.split("/", 1) for t in context.user_agent.split(" "))
-    tokens["c"] = tokens["e"] = tokens["s"] = "."
+    for tok in ALL - {"aau"}:
+        if tok in tokens:
+            tokens[tok] = "."
     from conda.cli import main_info
 
     info_dict = main_info.get_info_dict()

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -19,7 +19,7 @@ def test_environment_token_with_target_prefix(tmpdir):
     assert prefix_token != tokens.environment_token()
 
 
-def test_token_string():
+def test_token_string(no_system_tokens):
     token_string = tokens.token_string()
     assert "aau/" in token_string
     assert "c/" in token_string
@@ -29,7 +29,7 @@ def test_token_string():
     assert "m/" not in token_string
 
 
-def test_token_string_disabled():
+def test_token_string_disabled(no_system_tokens):
     token_string = tokens.token_string(enabled=False)
     assert "aau/" in token_string
     assert "c/" not in token_string
@@ -46,7 +46,7 @@ def test_token_string_with_system(system_tokens):
     assert "m/" + mch_token in token_string
 
 
-def test_token_string_no_client_token(monkeypatch, system_tokens):
+def test_token_string_no_client_token(monkeypatch, no_system_tokens):
     def _mock_saved_token(*args, **kwargs):
         return ""
 
@@ -54,46 +54,42 @@ def test_token_string_no_client_token(monkeypatch, system_tokens):
     monkeypatch.setattr(tokens, "_saved_token", _mock_saved_token)
 
     token_string = tokens.token_string()
-    org_token, mch_token = system_tokens
     assert "c/" not in token_string
     assert "s/" in token_string
     assert "e/env_token" in token_string
-    assert "o/" + org_token in token_string
-    assert "m/" + mch_token in token_string
+    assert "o/" not in token_string
+    assert "m/" not in token_string
 
 
-def test_token_string_no_environment_token(monkeypatch, system_tokens):
+def test_token_string_no_environment_token(monkeypatch, no_system_tokens):
     monkeypatch.setattr(tokens, "environment_token", lambda prefix: "")
 
     token_string = tokens.token_string()
-    org_token, mch_token = system_tokens
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
-    assert "o/" + org_token in token_string
-    assert "m/" + mch_token in token_string
+    assert "o/" not in token_string
+    assert "m/" not in token_string
 
 
-def test_token_string_full_readonly(monkeypatch, system_tokens):
+def test_token_string_full_readonly(monkeypatch, no_system_tokens):
     monkeypatch.setattr(utils, "READ_CHAOS", "ce")
     monkeypatch.setattr(utils, "WRITE_CHAOS", "ce")
     token_string = tokens.token_string()
-    org_token, mch_token = system_tokens
     assert "c/" not in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
-    assert "o/" + org_token in token_string
-    assert "m/" + mch_token in token_string
+    assert "o/" not in token_string
+    assert "m/" not in token_string
 
 
-def test_token_string_env_readonly(monkeypatch, system_tokens):
+def test_token_string_env_readonly(monkeypatch, no_system_tokens):
     monkeypatch.setattr(utils, "READ_CHAOS", "e")
     monkeypatch.setattr(utils, "WRITE_CHAOS", "e")
 
     token_string = tokens.token_string()
-    org_token, mch_token = system_tokens
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" not in token_string
-    assert "o/" + org_token in token_string
-    assert "m/" + mch_token in token_string
+    assert "o/" not in token_string
+    assert "m/" not in token_string


### PR DESCRIPTION
- Adds a new config value `anaconda_heartbeat`, which is off by default
- Adds the heartbeat to the activation pre-command hook
- Adds a new integration test to verify correct heartbeat generation, and verifying that it is not generated if it is turned off

Also, after discussion with @jezdez we have removed the "admin override" functionality previously present in the tokens file. Rather, we are relying on the ability for admins to provide locked overrides via the `#!final` declaration; see here:

https://www.anaconda.com/blog/conda-configuration-engine-power-users

So there is no need for the presence of an `org_token` to override an `anaconda_anon_usage: False` setting, because a system-installed `condarc` can do this:
```
anaconda_anon_usage: true #!final
```
and no user settings will change that.