### PR TITLE
reformat multiple system token support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,14 +104,14 @@ jobs:
         pytest
         python tests/integration/test_config.py
     - name: Test heartbeats (pwsh)
-      if: matrix.os == 'windows-latest' && (matrix.cversion == '24.11.3' || matrix.cversion == '25.1.1')
+      if: matrix.os == 'windows-latest' && matrix.cversion == '25.1.1'
       shell: pwsh
       run: |
         .\testenv\shell\condabin\conda-hook.ps1
         conda activate base
         python tests\integration\test_heartbeats.py powershell
     - name: Test heartbeats (cmd)
-      if: matrix.os == 'windows-latest' && (matrix.cversion == '24.11.3' || matrix.cversion == '25.1.1')
+      if: matrix.os == 'windows-latest' && matrix.cversion == '25.1.1'
       shell: cmd
       run: |
         call .\testenv\Scripts\activate.bat
@@ -119,7 +119,7 @@ jobs:
         python tests\integration\test_heartbeats.py cmd.exe
         if %errorlevel% neq 0 exit 1
     - name: Test heartbeats (bash)
-      if: matrix.os != 'windows-latest' && (matrix.cversion == '24.11.3' || matrix.cversion == '25.1.1')
+      if: matrix.os != 'windows-latest' && matrix.cversion == '25.1.1'
       run: |
         source ./testenv/bin/activate
         conda info

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -91,7 +91,7 @@ def _search_path():
     return result
 
 
-def _system_token(fname, what):
+def _system_tokens(fname, what):
     """
     Returns an organization or machine token installed somewhere
     in the conda path. Unlike most tokens, these will typically
@@ -104,30 +104,28 @@ def _system_token(fname, what):
         fpath = join(path, fname)
         if not isfile(fpath):
             continue
-        t_tokens = _read_file(fpath, what + "token", single_line=True)
+        t_tokens = _read_file(fpath, what + " token", single_line=True)
         if t_tokens:
             for token in t_tokens.split("/"):
                 if token not in tokens:
                     tokens.append(token)
-    if tokens:
-        return "/".join(tokens)
-    _debug("No %s tokens found", what)
+    return tokens
 
 
 @cached
-def organization_token():
+def organization_tokens():
     """
     Returns the organization token.
     """
-    return _system_token(ORG_TOKEN_NAME, "organization")
+    return _system_tokens(ORG_TOKEN_NAME, "organization")
 
 
 @cached
-def machine_token():
+def machine_tokens():
     """
     Returns the machine token.
     """
-    return _system_token(MACHINE_TOKEN_NAME, "machine")
+    return _system_tokens(MACHINE_TOKEN_NAME, "machine")
 
 
 @cached
@@ -202,8 +200,8 @@ def all_tokens(prefix=None):
         session_token(),
         environment_token(prefix),
         anaconda_cloud_token(),
-        organization_token(),
-        machine_token(),
+        organization_tokens(),
+        machine_tokens(),
     )
 
 
@@ -225,9 +223,9 @@ def token_string(prefix=None, enabled=True):
         if values.anaconda_cloud:
             parts.append("a/" + values.anaconda_cloud)
         if values.organization:
-            parts.append("o/" + values.organization)
+            parts.extend("o/" + t for t in values.organization)
         if values.machine:
-            parts.append("m/" + values.machine)
+            parts.extend("m/" + t for t in values.machine)
     else:
         _debug("anaconda_anon_usage disabled by config")
     result = " ".join(parts)

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -109,6 +109,8 @@ def _system_tokens(fname, what):
             for token in t_tokens.split("/"):
                 if token not in tokens:
                     tokens.append(token)
+    if not tokens:
+        _debug("No %s tokens found", what)
     return tokens
 
 

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -115,7 +115,7 @@ def _system_tokens(fname, what):
 @cached
 def organization_tokens():
     """
-    Returns the organization token.
+    Returns the list of organization tokens.
     """
     return _system_tokens(ORG_TOKEN_NAME, "organization")
 
@@ -123,7 +123,7 @@ def organization_tokens():
 @cached
 def machine_tokens():
     """
-    Returns the machine token.
+    Returns the list of machine tokens.
     """
     return _system_tokens(MACHINE_TOKEN_NAME, "machine")
 
@@ -222,6 +222,10 @@ def token_string(prefix=None, enabled=True):
             parts.append("e/" + values.environment)
         if values.anaconda_cloud:
             parts.append("a/" + values.anaconda_cloud)
+        # Organization and machine tokens can potentially be
+        # multi-valued, and this is rendered in the user agent
+        # string as multiple instances separated by spaces. This
+        # was chosen to facilitate easier filtering & search
         if values.organization:
             parts.extend("o/" + t for t in values.organization)
         if values.machine:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import tempfile
-from os import remove
+from os import mkdir, remove
 from os.path import dirname, join
 
 import pytest
@@ -14,39 +14,53 @@ def aau_token_path():
     return join(tokens.CONFIG_DIR, "aau_token")
 
 
-def _system_token_path():
+def _system_token_path(npaths=1):
     with tempfile.TemporaryDirectory() as tname:
         utils._cache_clear("_search_path", "organization_token", "machine_token")
         tname = tname.replace("\\", "/")
         o_path = c_constants.SEARCH_PATH
-        n_path = (
-            "/tmp/fake/condarc.d/",
-            tname + "/.condarc",
-            tname + "/condarc",
-            tname + "/condarc.d/",
-        )
+        n_path = ("/tmp/fake/condarc.d/",)
+        for k in range(npaths):
+            tdir = join(tname, "t%d" % k)
+            mkdir(tdir)
+            n_path += (tdir + "/.condarc", tdir + "/condarc", tdir + "/condarc.d/")
         c_constants.SEARCH_PATH = n_path
         yield n_path
         c_constants.SEARCH_PATH = o_path
-        utils._cache_clear("_search_path", "organization_token", "machine_token")
+        utils._cache_clear("_search_path", "organization_tokens", "machine_tokens")
+
+
+def _build_tokens(tpath, machine=True):
+    otoken = utils._random_token()
+    with open(dirname(tpath) + "/org_token", "w") as fp:
+        fp.write(otoken + "\n# Anaconda organization token\n")
+    if machine:
+        mtoken = utils._random_token()
+        with open(dirname(tpath) + "/machine_token", "w") as fp:
+            fp.write(mtoken + "\n# Anaconda machine token\n")
+    else:
+        mtoken = None
+    return (otoken, mtoken)
 
 
 @pytest.fixture
 def no_system_tokens():
-    for tpath in _system_token_path():
+    for tpath in _system_token_path(0):
         yield (None, None)
 
 
 @pytest.fixture
 def system_tokens():
-    for tpaths in _system_token_path():
-        otoken = utils._random_token()
-        mtoken = utils._random_token()
-        with open(dirname(tpaths[1]) + "/org_token", "w") as fp:
-            fp.write(otoken + "\n# Anaconda organization token\n")
-        with open(dirname(tpaths[1]) + "/machine_token", "w") as fp:
-            fp.write(mtoken + "\n# Anaconda machine token\n")
-        yield (otoken, mtoken)
+    for tpaths in _system_token_path(1):
+        yield _build_tokens(tpaths[1])
+
+
+@pytest.fixture
+def two_org_tokens():
+    for tpaths in _system_token_path(2):
+        t1 = _build_tokens(tpaths[1], True)
+        t2 = _build_tokens(tpaths[4], False)
+        yield t1 + t2[:1]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_heartbeats.py
+++ b/tests/integration/test_heartbeats.py
@@ -152,6 +152,9 @@ for hval in ("true", "false", "delay"):
             print(f"{hval:5} {stype:10} {envname:{maxlen}} {status or 'OK'}")
             if status:
                 print("|", " ".join(cmd))
+                for line in proc.stdout.splitlines():
+                    if line.strip():
+                        print(">", line)
                 for line in proc.stderr.splitlines():
                     if line.strip():
                         print("!", line)

--- a/tests/integration/test_heartbeats.py
+++ b/tests/integration/test_heartbeats.py
@@ -105,7 +105,6 @@ print("Expected host:", exp_host)
 print("Expected path:", exp_path)
 print("Expected tokens:", ",".join(expected))
 need_header = True
-port = 8080
 for hval in ("true", "false", "delay"):
     os.environ["CONDA_ANACONDA_HEARTBEAT"] = str(hval != "false").lower()
     for envname in envs:
@@ -116,10 +115,9 @@ for hval in ("true", "false", "delay"):
             # making it to repo.anaconda.com. The tester returns 404 for all requests.
             # It also has the advantage of making sure our code respects proxies
             # fmt: off
-            cmd = ["proxyspy", "--port", str(port), "--return-code", "404"]
+            cmd = ["proxyspy", "--return-code", "404"]
             cmd.extend(["--delay", "2.0" if hval == "delay" else "0.1"])
             cmd.extend(["--", "conda", "shell." + stype, "activate", envname])
-            port += 1
             # fmt: on
             proc = subprocess.run(
                 cmd,

--- a/tests/integration/test_heartbeats.py
+++ b/tests/integration/test_heartbeats.py
@@ -105,6 +105,7 @@ print("Expected host:", exp_host)
 print("Expected path:", exp_path)
 print("Expected tokens:", ",".join(expected))
 need_header = True
+port = 8080
 for hval in ("true", "false", "delay"):
     os.environ["CONDA_ANACONDA_HEARTBEAT"] = str(hval != "false").lower()
     for envname in envs:
@@ -115,10 +116,10 @@ for hval in ("true", "false", "delay"):
             # making it to repo.anaconda.com. The tester returns 404 for all requests.
             # It also has the advantage of making sure our code respects proxies
             # fmt: off
-            cmd = ["proxyspy", "--return-code", "404"]
-            if hval == "delay":
-                cmd.extend(["--delay", "2.0"])
+            cmd = ["proxyspy", "--port", str(port), "--return-code", "404"]
+            cmd.extend(["--delay", "2.0" if hval == "delay" else "0.1"])
             cmd.extend(["--", "conda", "shell." + stype, "activate", envname])
+            port += 1
             # fmt: on
             proc = subprocess.run(
                 cmd,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest
 pytest-cov
-conda-forge::proxyspy
+mcg::proxyspy>=0.1.2.1

--- a/tests/unit/test_patch.py
+++ b/tests/unit/test_patch.py
@@ -38,10 +38,12 @@ def test_user_agent_system_tokens(system_tokens):
 
 
 def test_user_agent_local_tokens():
+    expected = []
     token_names = ("anaconda_cloud", "organization", "machine")
-    expected = [
-        tname[0] for tname in token_names if getattr(tokens, tname + "_token")()
-    ]
+    for is_plural, tname in enumerate(token_names):
+        fn = tname + "_token" + ("s" if is_plural else "")
+        if getattr(tokens, fn)():
+            expected.append(tname[0])
     _assert_has_expected_tokens(expected)
 
 

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -44,6 +44,16 @@ def test_token_string_with_system(system_tokens):
     token_string = tokens.token_string()
     assert "o/" + org_token in token_string
     assert "m/" + mch_token in token_string
+    assert token_string.count(" o/") == 1
+
+
+def test_token_string_with_two_org_tokens(two_org_tokens):
+    org_token, mch_token, org_token2 = two_org_tokens
+    token_string = tokens.token_string()
+    assert "o/" + org_token in token_string
+    assert "m/" + mch_token in token_string
+    assert "o/" + org_token2 in token_string
+    assert token_string.count(" o/") == 2
 
 
 def test_token_string_no_client_token(monkeypatch, no_system_tokens):


### PR DESCRIPTION
When there are multiple organization or machine tokens on the conda path, we include them all in the user agent string. We currently concatenate them into a single user agent token; e.g.
```
o/org1/org2
```
But it would be easier to search logs if they were separate:
```
o/org1 o/org2
```