### PR TITLE
support for alternative heartbeat urls

### DIFF
--- a/anaconda_anon_usage/heartbeat.py
+++ b/anaconda_anon_usage/heartbeat.py
@@ -87,7 +87,9 @@ def attempt_heartbeat(prefix=None, dry_run=False, channel=None, path=None):
             _print("No valid heartbeat channel")
             return
         url = urljoin(base, channel or "main") + "/"
-    url = urljoin(url, path or HEARTBEAT_PATH)
+    if path is None:
+        path = HEARTBEAT_PATH
+    url = urljoin(url, path)
 
     _print("Heartbeat url: %s", url)
     if prefix:


### PR DESCRIPTION
In order to support situations such as:
- Direct access to the Anaconda repository is obscured by an internal proxy URL
- There is a desire to transmit the heartbeat URL to an internal resource

This PR allows the `anaconda_heartbeat` config value to be not just `true` or `false` but also a full URL. In the latter case, that is the precise URL that is used to deliver the heartbeat ping. Validation is implemented to confirm that it has a valid scheme and netloc, but any path or query values are preserved.

Administrators can implement this by including the value in their `/etc/conda/condarc`; e.g.
```
anaconda_heartbeat: https://repo.anaconda.com/pkgs/main/noarch/activate-0.0.1-0.conda #!final
```