### PR TITLE
Add hostid-based refresh of client token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,10 @@ jobs:
         mv conda-bld $CONDA/
         version=$(conda search local::anaconda-anon-usage | tail -1 | awk '{print $2}')
         pkg="anaconda-anon-usage=$version"
+        # This is to address an issue with Linux ARM Python 3.9 only
+        if [[ "${{ matrix.os }}" = ubuntu-*-arm ]]; then ppkg="python<3.9|>=3.10"; else ppkg=""; fi
         conda install -c local anaconda-client constructor $pkg
-        conda create -p ./testenv -c local $pkg conda==${{ matrix.cversion }} --file tests/requirements.txt
+        conda create -p ./testenv -c local $ppkg $pkg conda==${{ matrix.cversion }} --file tests/requirements.txt
         mkdir -p ./testenv/envs
         conda create -p ./testenv/envs/testchild1 python --yes
         conda create -p ./testenv/envs/testchild2 python --yes

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -138,7 +138,7 @@ def client_token():
     that fails, an empty string is returned.
     """
     fpath = join(CONFIG_DIR, "aau_token")
-    return _saved_token(fpath, "client")
+    return _saved_token(fpath, "client", node_tie=True)
 
 
 @cached

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -202,9 +202,11 @@ def _get_node_str():
     Returns a base64-encoded representation of the host ID
     as determined by uuid.getnode().
     """
-    val = uuid.getnode().to_bytes(6, byteorder=sys.byteorder)
-    val = base64.urlsafe_b64encode(val)
-    val = val.decode("ascii")
+    val = uuid._unix_getnode() or uuid._windll_getnode()
+    if val:
+        val = val.to_bytes(6, byteorder=sys.byteorder)
+        val = base64.urlsafe_b64encode(val)
+        val = val.decode("ascii")
     return val
 
 

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -63,10 +63,13 @@ def cached(func):
 
 def _cache_clear(*args):
     global CACHE
+    global __nodestr
     if not args:
         CACHE.clear()
     else:
         CACHE = {k: v for k, v in CACHE.items() if k[0] not in args}
+    if "client_token" not in CACHE:
+        uuid._node = __nodestr = None
 
 
 def _debug(s, *args, error=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import tempfile
-from os import mkdir, remove
+from os import mkdir
 from os.path import dirname, join
 
 import pytest
@@ -11,7 +11,11 @@ from anaconda_anon_usage import tokens, utils
 
 @pytest.fixture
 def aau_token_path():
-    return join(tokens.CONFIG_DIR, "aau_token")
+    old_dir = tokens.CONFIG_DIR
+    with tempfile.TemporaryDirectory() as tname:
+        tokens.CONFIG_DIR = tname
+        yield join(tname, "aau_token")
+    tokens.CONFIG_DIR = old_dir
 
 
 def _system_token_path(npaths=1):
@@ -61,17 +65,6 @@ def two_org_tokens():
         t1 = _build_tokens(tpaths[1], True)
         t2 = _build_tokens(tpaths[4], False)
         yield t1 + t2[:1]
-
-
-@pytest.fixture(autouse=True)
-def token_cleanup(request, aau_token_path):
-    def _remove():
-        try:
-            remove(aau_token_path)
-        except FileNotFoundError:
-            pass
-
-    request.addfinalizer(_remove)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
+pytest-mock
 mcg::proxyspy>=0.1.3

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,7 +1,4 @@
-import sys
 from os.path import exists
-
-import pytest
 
 from anaconda_anon_usage import tokens, utils
 
@@ -12,7 +9,6 @@ def test_client_token(aau_token_path):
     assert exists(aau_token_path)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_client_token_add_hostid(aau_token_path):
     assert not exists(aau_token_path)
     token1 = utils._random_token()
@@ -29,7 +25,6 @@ def test_client_token_add_hostid(aau_token_path):
     assert token4 == token2, (token2, token4)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_client_token_replace_hostid(aau_token_path):
     assert not exists(aau_token_path)
     token1 = utils._random_token()

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -9,6 +9,32 @@ def test_client_token(aau_token_path):
     assert exists(aau_token_path)
 
 
+def test_client_token_add_hostid(aau_token_path):
+    assert not exists(aau_token_path)
+    token1 = utils._random_token()
+    with open(aau_token_path, "w") as fp:
+        fp.write(token1)
+    token2 = tokens.client_token()
+    assert token1 == token2
+    with open(aau_token_path) as fp:
+        token3 = fp.read()
+    assert token3.split(" ", 1)[0] == token2, (token2, token3)
+    assert token3.split(" ", 1)[1] == utils._get_node_str(), token3
+
+
+def test_client_token_replace_hostid(aau_token_path):
+    assert not exists(aau_token_path)
+    token1 = utils._random_token()
+    with open(aau_token_path, "w") as fp:
+        fp.write(token1 + " xxxxxxx")
+    token2 = tokens.client_token()
+    assert token1 != token2
+    with open(aau_token_path) as fp:
+        token3 = fp.read()
+    assert token3.split(" ", 1)[0] == token2, (token2, token3)
+    assert token3.split(" ", 1)[1] == utils._get_node_str(), token3
+
+
 def test_environment_token_without_monkey_patching():
     assert tokens.environment_token() is not None
 

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,4 +1,7 @@
+import sys
 from os.path import exists
+
+import pytest
 
 from anaconda_anon_usage import tokens, utils
 
@@ -9,6 +12,7 @@ def test_client_token(aau_token_path):
     assert exists(aau_token_path)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_client_token_add_hostid(aau_token_path):
     assert not exists(aau_token_path)
     token1 = utils._random_token()
@@ -25,6 +29,7 @@ def test_client_token_add_hostid(aau_token_path):
     assert token4 == token2, (token2, token4)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
 def test_client_token_replace_hostid(aau_token_path):
     assert not exists(aau_token_path)
     token1 = utils._random_token()

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -20,6 +20,9 @@ def test_client_token_add_hostid(aau_token_path):
         token3 = fp.read()
     assert token3.split(" ", 1)[0] == token2, (token2, token3)
     assert token3.split(" ", 1)[1] == utils._get_node_str(), token3
+    utils._cache_clear()
+    token4 = tokens.client_token()
+    assert token4 == token2, (token2, token4)
 
 
 def test_client_token_replace_hostid(aau_token_path):
@@ -33,6 +36,9 @@ def test_client_token_replace_hostid(aau_token_path):
         token3 = fp.read()
     assert token3.split(" ", 1)[0] == token2, (token2, token3)
     assert token3.split(" ", 1)[1] == utils._get_node_str(), token3
+    utils._cache_clear()
+    token4 = tokens.client_token()
+    assert token4 == token2, (token2, token4)
 
 
 def test_environment_token_without_monkey_patching():

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -9,6 +9,19 @@ def test_client_token(aau_token_path):
     assert exists(aau_token_path)
 
 
+def test_client_token_no_nodeid(aau_token_path, mocker):
+    m1 = mocker.patch("uuid._unix_getnode")
+    m1.return_value = None
+    m2 = mocker.patch("uuid._windll_getnode")
+    m2.return_value = None
+    token1 = tokens.client_token()
+    assert token1 != "" and exists(aau_token_path)
+    with open(aau_token_path) as fp:
+        token2 = fp.read()
+    # No hostid saved in the token file
+    assert token1 == token2, (token1, token2)
+
+
 def test_client_token_add_hostid(aau_token_path):
     assert not exists(aau_token_path)
     token1 = utils._random_token()


### PR DESCRIPTION
Problem: suppose someone builds an AMI which includes some `conda` installations. It will automatically create a client token and store it in `~/.conda/aau_token`. If this AMI is them used multiple times, this token will be present in all copies. This results in a loss of uniqueness for this client ID. This behavior is being observed in our data today, for both Linux and Windows machines.

To resolve this issue, we have modified the token read/write capability to allow the host ID to be included in the file `~/.conda/aau_token` alongside the client token. This host ID is never transmitted in the user agent string; only the random client token is. But when it _is_ present, the code will compare its value against the value of `uuid.getnode()`. If there is a mismatch, then the client ID is _regenerated_ and _re-saved_. This approach will de-duplicate the client ID in scenarios such as above.

Note that `uuid.getnode()` can sometimes fail to obtain a stable host ID, in which case it generates a random value. We had to jump through some hoops to figure out conclusively whether or not a random value was used. Turns out it's not that simple on Windows. [EDIT: after more experimentation and discussion we have decided to trust that, in all scenarios that matter, `uuid.getnode()` will produce a repeatable result.]