### PR TITLE
move the hostid from the token file to a sidecar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         # 23.7.0 : first plugin-based variant, but conda info --envs --json is broken
         # 23.9.0 : last variant with the classic default solver
         # 23.10.0 : first variant with the libmamba default solver
-        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.5.2', '23.7.1', '23.9.0', '23.10.0', '24.11.3', '25.1.1']
+        cversion: ['4.11.0', '4.14.0', '22.11.1', '23.5.2', '23.7.1', '23.9.0', '23.10.0', '24.11.3', '25.3.1']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Retrieve the source code
@@ -135,7 +135,6 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: cmd
       run: |
-        source $CONDA/bin/activate
         cd tests/integration
         start /wait AIDTest-1.0-Windows-x86_64.exe /S /D=%USERPROFILE%\aidtest
         call %USERPROFILE%\aidtest\Scripts\activate

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -23,7 +23,8 @@ def test_client_token_no_nodeid(aau_token_path, mocker):
 
 
 def test_client_token_add_hostid(aau_token_path):
-    assert not exists(aau_token_path)
+    node_path = aau_token_path + "_host"
+    assert not exists(aau_token_path) and not exists(node_path)
     token1 = utils._random_token()
     with open(aau_token_path, "w") as fp:
         fp.write(token1)
@@ -31,24 +32,50 @@ def test_client_token_add_hostid(aau_token_path):
     assert token1 == token2
     with open(aau_token_path) as fp:
         token3 = fp.read()
-    assert token3.split(" ", 1)[0] == token2, (token2, token3)
-    assert token3.split(" ", 1)[1] == utils._get_node_str(), token3
+    with open(node_path) as fp:
+        saved_node = fp.read()
+    assert token3 == token2, (token2, token3)
+    assert saved_node == utils._get_node_str(), saved_node
     utils._cache_clear()
     token4 = tokens.client_token()
     assert token4 == token2, (token2, token4)
 
 
 def test_client_token_replace_hostid(aau_token_path):
-    assert not exists(aau_token_path)
+    node_path = aau_token_path + "_host"
+    assert not exists(aau_token_path) and not exists(node_path)
     token1 = utils._random_token()
     with open(aau_token_path, "w") as fp:
-        fp.write(token1 + " xxxxxxx")
+        fp.write(token1)
+    with open(node_path, "w") as fp:
+        fp.write("xxxxxxxx")
     token2 = tokens.client_token()
     assert token1 != token2
     with open(aau_token_path) as fp:
         token3 = fp.read()
-    assert token3.split(" ", 1)[0] == token2, (token2, token3)
-    assert token3.split(" ", 1)[1] == utils._get_node_str(), token3
+    with open(node_path) as fp:
+        saved_node = fp.read()
+    assert token3 == token2, (token2, token3)
+    assert saved_node == utils._get_node_str(), saved_node
+    utils._cache_clear()
+    token4 = tokens.client_token()
+    assert token4 == token2, (token2, token4)
+
+
+def test_client_token_migrate_hostid(aau_token_path):
+    node_path = aau_token_path + "_host"
+    assert not exists(aau_token_path) and not exists(node_path)
+    token1 = utils._random_token()
+    with open(aau_token_path, "w") as fp:
+        fp.write(token1 + " " + utils._get_node_str())
+    token2 = tokens.client_token()
+    assert token1 == token2
+    with open(aau_token_path) as fp:
+        token3 = fp.read()
+    with open(node_path) as fp:
+        saved_node = fp.read()
+    assert token3 == token2, (token2, token3)
+    assert saved_node == utils._get_node_str(), saved_node
     utils._cache_clear()
     token4 = tokens.client_token()
     assert token4 == token2, (token2, token4)


### PR DESCRIPTION
In #149 we added "host id" tracking to the client token. We did this by inserting a copy of the host ID into the `~/.conda/aau_token` file, separated from the actual token by a space. The host ID is never sent to our servers, it is only used to detect if the host ID changes; and if it does change, the client ID is regenerated. This prevents VM clones from reusing the same client ID.

Unfortunately, if someone downgrades from 0.7.0 to older versions of a-a-u, this additional content will be unexpected and can break a-a-u. To resolve this, this PR moves the host ID to a sidecar file `~/.conda/aau_token_host`. It implements a migration plan as well: if the host ID is found within the file, it strips it out, while keeping the client ID the same.

A third host ID test has been created: one for no host ID, one for a changed host ID, and one for migrating the host ID to a sidecar.