### PR TITLE
Support anaconda.cloud -> anaconda.com migration in keyring

### DIFF
--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -28,6 +28,7 @@ Tokens = namedtuple(
     ),
 )
 CONFIG_DIR = expanduser("~/.conda")
+ANACONDA_DIR = expanduser("~/.anaconda")
 ORG_TOKEN_NAME = "org_token"
 MACHINE_TOKEN_NAME = "machine_token"
 
@@ -165,10 +166,16 @@ def environment_token(prefix=None):
 
 @cached
 def anaconda_cloud_token():
+    """Retrieve Anaconda Cloud token from keyring.
+
+    Examines all entries under 'Anaconda Cloud' in the keyring and
+    selects the token with the latest expiration date. This handles
+    migration from 'anaconda.cloud' to 'anaconda.com' entries.
+
+    Returns:
+        str: Base64-encoded token, or None if no valid token found.
     """
-    Returns the token for the logged-in anaconda user, if present.
-    """
-    fpath = expanduser(join("~", ".anaconda", "keyring"))
+    fpath = expanduser(join(ANACONDA_DIR, "keyring"))
     data = _read_file(fpath, "anaconda keyring")
     if not data:
         return

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,3 +1,6 @@
+import base64
+import re
+import uuid
 from os.path import exists
 
 from anaconda_anon_usage import tokens, utils
@@ -97,6 +100,7 @@ def test_token_string(no_system_tokens):
     assert "c/" in token_string
     assert "s/" in token_string
     assert "e/" in token_string
+    assert "a/" not in token_string
     assert "o/" not in token_string
     assert "m/" not in token_string
 
@@ -107,6 +111,7 @@ def test_token_string_disabled(no_system_tokens):
     assert "c/" not in token_string
     assert "s/" not in token_string
     assert "e/" not in token_string
+    assert "a/" not in token_string
     assert "o/" not in token_string
     assert "m/" not in token_string
 
@@ -175,3 +180,12 @@ def test_token_string_env_readonly(monkeypatch, no_system_tokens):
     assert "e/" not in token_string
     assert "o/" not in token_string
     assert "m/" not in token_string
+
+
+def test_anaconda_string(anaconda_uid):
+    token_string = tokens.token_string()
+    assert "a/" in token_string
+    expected = uuid.UUID(anaconda_uid).bytes
+    expected = base64.urlsafe_b64encode(expected).decode("ascii").rstrip("=")
+    aval = re.sub("^.*a/", "", token_string).split(" ", 1)[0]
+    assert aval == expected


### PR DESCRIPTION
Our Anaconda Cloud keyring parsing is failing now that we have migrated the keyring record from "anaconda.cloud" to "anaconda.com". This modification still assumes that these records live in the "Anaconda Cloud" master record. But instead of expecting the record to live in `data["Anaconda Cloud"]["anaconda.cloud"]`, it examines _all_ of the records in `data["Anaconda Cloud"]` and selects the `sub` associated with the latest expiration date.