### PR TITLE
Allow org and mch tokens to be supplied by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ a random token ready for use as an organization or machine token:
 ```
 python -m anaconda_anon_usage.tokens --random
 ```
+Tokens can also be constructed manually, but must include only characters
+in the ranges `a-z`, `A-Z`, `0-9`, `-`, and `_`, and no spaces.
 
 ### Activation heartbeats
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ a random token ready for use as an organization or machine token:
 python -m anaconda_anon_usage.tokens --random
 ```
 Tokens can also be constructed manually, but must include only characters
-in the ranges `a-z`, `A-Z`, `0-9`, `-`, and `_`, and no spaces.
+in the ranges `a-z`, `A-Z`, `0-9`, `-`, and `_`, and no spaces. A maximum
+length of 36 characters is also enforced, to help ensure that the total
+header length remains well within HTTP limits.
 
 ### Activation heartbeats
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ on Unix/macOS and `C:\ProgramData\conda\` on Windows:
   aggressive_update_packages: [anaconda-anon-usage]
   ```
 
+These tokens can also be activated using environment variables:
+
+- `org_token`: `ANACONDA_ANON_USAGE_ORG_TOKEN`
+- `machine_token`: `ANACONDA_ANON_USAGE_MACHINE_TOKEN`
+
+The environment variable approach may be appropriate in CI/CD systems or
+containerized workflows.
+
+Unlike the client, environment, and session tokens, it is possible to provide
+multiple organization or machine tokens. For example, one can be placed in
+`/etc/org_token` and another in an environment variable. When this occurs,
+all of them are included in the user agent string, to ensure that one does
+not shadow the other.
+
 For convenience, the `tokens` submodule includes a function to generate
 a random token ready for use as an organization or machine token:
 ```

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -32,7 +32,10 @@ CONFIG_DIR = expanduser("~/.conda")
 ANACONDA_DIR = expanduser("~/.anaconda")
 ORG_TOKEN_NAME = "org_token"
 MACHINE_TOKEN_NAME = "machine_token"
-VALID_TOKEN_RE = r"^(?:\w|-)+$"
+
+# System tokens may consist of only letters, numbers,
+# underscores, and dashes, with no more than 36 characters.
+VALID_TOKEN_RE = r"^(?:[A-Za-z0-9]|_|-){1,36}$"
 
 
 @cached
@@ -103,15 +106,15 @@ def _system_tokens(fname, what):
     """
     tokens = []
     env_name = "ANACONDA_ANON_USAGE_" + fname.upper()
-    t_tokens = environ.get(env_name)
-    if t_tokens:
-        _debug("Found %s token in environment: %s", what, t_tokens)
-        tokens.extend(t_tokens.split("/"))
+    t_token = environ.get(env_name)
+    if t_token:
+        _debug("Found %s token in environment: %s", what, t_token)
+        tokens.append(t_token)
     for path in _search_path():
         fpath = join(path, fname)
         if isfile(fpath):
-            t_tokens = _read_file(fpath, what + " token", single_line=True)
-            tokens.extend(t_tokens.split("/"))
+            t_token = _read_file(fpath, what + " token", single_line=True)
+            tokens.append(t_token)
     # Deduplicate while preserving order
     tokens = list(dict.fromkeys(t for t in tokens if t))
     if not tokens:

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -116,12 +116,13 @@ def _system_tokens(fname, what):
     tokens = list(dict.fromkeys(t for t in tokens if t))
     if not tokens:
         _debug("No %s tokens found", what)
-    invalid = [t for t in tokens if not re.match(VALID_TOKEN_RE, t)]
-    if invalid:
-        tokens = [t for t in tokens if t not in invalid]
-        invalid = ", ".join(invalid)
+    # Make sure the tokens we omit have only valid characters, so any
+    # server-side token parsing is not frustrated.
+    valid = [t for t in tokens if re.match(VALID_TOKEN_RE, t)]
+    if len(valid) < len(tokens):
+        invalid = ", ".join(t for t in tokens if t not in valid)
         _debug("One or more invalid %s tokens discarded: %s", what, invalid)
-    return tokens
+    return valid
 
 
 @cached

--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -10,7 +10,6 @@ import re
 import sys
 import uuid
 from collections import namedtuple
-from itertools import chain
 from os import environ
 from os.path import expanduser, isdir, isfile, join
 
@@ -103,21 +102,18 @@ def _system_tokens(fname, what):
     along the path, in which case we combine them
     """
     tokens = []
-    for path in chain((None,), _search_path()):
-        if path is None:
-            env_name = "ANACONDA_ANON_USAGE_" + fname.upper()
-            t_tokens = environ.get(env_name)
-            if not t_tokens:
-                continue
-            _debug("Found %s token in environment: %s", what, t_tokens)
-        else:
-            fpath = join(path, fname)
-            if not isfile(fpath):
-                continue
+    env_name = "ANACONDA_ANON_USAGE_" + fname.upper()
+    t_tokens = environ.get(env_name)
+    if t_tokens:
+        _debug("Found %s token in environment: %s", what, t_tokens)
+        tokens.extend(t_tokens.split("/"))
+    for path in _search_path():
+        fpath = join(path, fname)
+        if isfile(fpath):
             t_tokens = _read_file(fpath, what + " token", single_line=True)
-        for token in t_tokens.split("/"):
-            if token and token not in tokens:
-                tokens.append(token)
+            tokens.extend(t_tokens.split("/"))
+    # Deduplicate while preserving order
+    tokens = list(dict.fromkeys(t for t in tokens if t))
     if not tokens:
         _debug("No %s tokens found", what)
     invalid = [t for t in tokens if not re.match(VALID_TOKEN_RE, t)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,11 +113,20 @@ def two_org_tokens(aau_token_path):
         yield t1 + t2[:1]
 
 
-@pytest.fixture(autouse=True)
-def client_token_string_cache_cleanup(request):
+def _env_clear():
     if "ANACONDA_AUTH_API_KEY" in environ:
         del environ["ANACONDA_AUTH_API_KEY"]
+    if "ANACONDA_ANON_USAGE_ORG_TOKEN" in environ:
+        del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
+    if "ANACONDA_ANON_USAGE_MACHINE_TOKEN" in environ:
+        del environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"]
+
+
+@pytest.fixture(autouse=True)
+def client_token_string_cache_cleanup(request):
+    _env_clear()
     request.addfinalizer(utils._cache_clear)
+    request.addfinalizer(_env_clear)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,6 +1,7 @@
 import base64
 import re
 import uuid
+from os import environ
 from os.path import exists
 
 from anaconda_anon_usage import tokens, utils
@@ -130,6 +131,26 @@ def test_token_string_with_two_org_tokens(two_org_tokens):
     assert "o/" + org_token in token_string
     assert "m/" + mch_token in token_string
     assert "o/" + org_token2 in token_string
+    assert token_string.count(" o/") == 2
+
+
+def test_token_string_with_env_org_token(no_system_tokens):
+    org_token_e = utils._random_token()
+    environ["ANACONDA_ANON_USAGE_ORG_TOKEN"] = org_token_e
+    token_string = tokens.token_string()
+    del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
+    assert "o/" + org_token_e in token_string
+
+
+def test_token_string_with_system_and_env(system_tokens):
+    org_token, mch_token = system_tokens
+    org_token_e = utils._random_token()
+    environ["ANACONDA_ANON_USAGE_ORG_TOKEN"] = org_token_e
+    token_string = tokens.token_string()
+    del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
+    assert "o/" + org_token in token_string
+    assert "o/" + org_token_e in token_string
+    assert "m/" + mch_token in token_string
     assert token_string.count(" o/") == 2
 
 

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -136,22 +136,31 @@ def test_token_string_with_two_org_tokens(two_org_tokens):
 
 def test_token_string_with_env_org_token(no_system_tokens):
     org_token_e = utils._random_token()
+    mch_token_e = utils._random_token()
     environ["ANACONDA_ANON_USAGE_ORG_TOKEN"] = org_token_e
+    environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"] = mch_token_e
     token_string = tokens.token_string()
     del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
+    del environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"]
     assert "o/" + org_token_e in token_string
+    assert "m/" + mch_token_e in token_string
 
 
 def test_token_string_with_system_and_env(system_tokens):
     org_token, mch_token = system_tokens
     org_token_e = utils._random_token()
+    mch_token_e = utils._random_token()
     environ["ANACONDA_ANON_USAGE_ORG_TOKEN"] = org_token_e
+    environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"] = mch_token_e
     token_string = tokens.token_string()
     del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
+    del environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"]
     assert "o/" + org_token in token_string
     assert "o/" + org_token_e in token_string
     assert "m/" + mch_token in token_string
+    assert "m/" + mch_token_e in token_string
     assert token_string.count(" o/") == 2
+    assert token_string.count(" m/") == 2
 
 
 def test_token_string_no_client_token(monkeypatch, no_system_tokens):

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -163,6 +163,18 @@ def test_token_string_with_system_and_env(system_tokens):
     assert token_string.count(" m/") == 2
 
 
+def test_token_string_with_invalid_tokens(no_system_tokens):
+    org_token_e = "invalid token"
+    mch_token_e = "superlongtokenthathasnobusinessbeinganactualtoken"
+    environ["ANACONDA_ANON_USAGE_ORG_TOKEN"] = org_token_e
+    environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"] = mch_token_e
+    token_string = tokens.token_string()
+    del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
+    del environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"]
+    assert "o/" not in token_string
+    assert "m/" not in token_string
+
+
 def test_token_string_no_client_token(monkeypatch, no_system_tokens):
     def _mock_saved_token(*args, **kwargs):
         return ""

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -140,8 +140,6 @@ def test_token_string_with_env_org_token(no_system_tokens):
     environ["ANACONDA_ANON_USAGE_ORG_TOKEN"] = org_token_e
     environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"] = mch_token_e
     token_string = tokens.token_string()
-    del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
-    del environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"]
     assert "o/" + org_token_e in token_string
     assert "m/" + mch_token_e in token_string
 
@@ -153,8 +151,6 @@ def test_token_string_with_system_and_env(system_tokens):
     environ["ANACONDA_ANON_USAGE_ORG_TOKEN"] = org_token_e
     environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"] = mch_token_e
     token_string = tokens.token_string()
-    del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
-    del environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"]
     assert "o/" + org_token in token_string
     assert "o/" + org_token_e in token_string
     assert "m/" + mch_token in token_string
@@ -169,8 +165,6 @@ def test_token_string_with_invalid_tokens(no_system_tokens):
     environ["ANACONDA_ANON_USAGE_ORG_TOKEN"] = org_token_e
     environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"] = mch_token_e
     token_string = tokens.token_string()
-    del environ["ANACONDA_ANON_USAGE_ORG_TOKEN"]
-    del environ["ANACONDA_ANON_USAGE_MACHINE_TOKEN"]
     assert "o/" not in token_string
     assert "m/" not in token_string
 


### PR DESCRIPTION
This was inspired by feedback from @mattmcnulty 

Customers who want to use organization and/or machine tokens to track access may find it challenging to do so with Docker containers and/or CI/CD systems. This PR enables them to be supplied in the environment variables `ANACONDA_ANON_USAGE_ORG_TOKEN` and `ANACONDA_ANON_USAGE_MACHINE_TOKEN`, respectively. These do not replace tokens included in the config path, but rather augment them. (This fact is further clarified in documentation changes.)

With expanded use of these system-supplied tokens it seemed important to perform some sort of validation. For historical reasons, org tokens have been allowed to be full UUID strings, so we impose a maximum length of 36; and allow characters in the ranges `A-Z`, `a-z`, `0-9`, `_`, and `-` to cover both base64-encoded tokens and UUID strings and kubernetes-style labels.