### PR TITLE
fix: handle None host ID in _get_node_str and regenerate token if mis…

### DIFF
--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -201,6 +201,12 @@ def _get_node_str():
     """
     Returns a base64-encoded representation of the host ID
     as determined by uuid.getnode().
+
+    Note:
+        - This may return None if the system cannot determine a MAC address.
+        - Some machines, virtual machines, or privacy-conscious OS configurations
+          may not expose a hardware MAC address, in which case the host ID is
+          unavailable.
     """
     val = uuid._unix_getnode() or uuid._windll_getnode()
     if val:
@@ -238,6 +244,9 @@ def _saved_token(fpath, what, must_exist=None, read_only=False, node_tie=False):
         npath = fpath + "_host"
         saved_node = _read_file(npath, "Host id", single_line=True) or ""
         true_node = saved_node or (xtra[0] if xtra else None)
+        if not current_node:
+            _debug("Host ID unavailable; regenerating token")
+            regenerate = True
         if regenerate or not true_node:
             pass
         elif true_node != current_node:


### PR DESCRIPTION
Some machines, virtual machines, or privacy-conscious OS configurations may not expose a hardware MAC address, in which case the host ID is unavailable.  
  
In this case, `val` is returned as `None` in `_get_node_str`, leading `_write_attempt` to give the user this unhelpful error message:  
```
Unexpected error writing token file:
  path: ~/.conda/aau_token_host
  exception: write() argument must be str, not None
```  
  
This PR updates `_saved_token()` to detect when `current_node` (the host ID) is falsey and sets `regenerate = True`.  
  
As a result, the environment token is regenerated instead of attempting to write a `None` host ID, preventing the error while preserving host anonymity.