### PR TITLE
fix: handle None host ID in _get_node_str

### DIFF
--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -201,13 +201,19 @@ def _get_node_str():
     """
     Returns a base64-encoded representation of the host ID
     as determined by uuid.getnode().
+
+    Note:
+        - May return an empty string if the system cannot determine a MAC address.
+        - Some machines, virtual machines, or privacy-conscious OS configurations
+          may not expose a hardware MAC address, in which case the host ID is
+          unavailable.
     """
     val = uuid._unix_getnode() or uuid._windll_getnode()
     if val:
         val = val.to_bytes(6, byteorder=sys.byteorder)
         val = base64.urlsafe_b64encode(val)
         val = val.decode("ascii")
-    return val
+    return val or ""
 
 
 def _saved_token(fpath, what, must_exist=None, read_only=False, node_tie=False):


### PR DESCRIPTION
Some machines, virtual machines, or privacy-conscious OS configurations may not expose a hardware MAC address, in which case the host ID is unavailable.  
  
In this case, `val` is returned as `None` in `_get_node_str`, leading `_write_attempt` to give the user this unhelpful error message:  
```
Unexpected error writing token file:
  path: ~/.conda/aau_token_host
  exception: write() argument must be str, not None
```  
  
This PR updates `_get_node_str()` to default to the empty string.  
  
This change proposes a pragmatic trade-off between ideal telemetry and software stability.  
  
The original intent of the host ID file is to de-duplicate tokens that have been copied to new machines. This fix would not uphold that principle in the rare case where a token is copied between two machines that *both* lack a hardware ID. In that scenario, both machines would be treated as a single client.  
  
The rationale for accepting this limitation is that there is no better alternative in this scenario. Ensuring analytics remains on for users in containerized and sandboxed environments is a higher priority than achieving perfect de-duplication in this specific edge case. Viewing the lack of a host ID as "opt-out" would be assuming user intent from a technical issue, which would be non-ideal.