### PR TITLE
reimplement _get_node_str due to python 3.13 change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         version=$(conda search local::anaconda-anon-usage | tail -1 | awk '{print $2}')
         pkg="anaconda-anon-usage=$version"
         # This is to address an issue with Linux ARM Python 3.9 only
-        if [[ "${{ matrix.os }}" = ubuntu-*-arm ]]; then ppkg="python<3.9|>=3.10,<3.13"; else ppkg="python<3.13"; fi
+        if [[ "${{ matrix.os }}" = ubuntu-*-arm ]]; then ppkg="python<3.9|>=3.10"; else ppkg=""; fi
         echo "-------------------------"
         echo "UPDATING BASE ENVIRONMENT"
         echo "-------------------------"

--- a/anaconda_anon_usage/utils.py
+++ b/anaconda_anon_usage/utils.py
@@ -203,6 +203,9 @@ def _get_node_str():
     as determined by uuid.getnode().
     """
     val = uuid._unix_getnode() or uuid._windll_getnode()
+    # https://github.com/anaconda/anaconda-anon-usage/pull/173
+    if not val and getattr(uuid, "_generate_time_safe", None):
+        val = uuid.UUID(bytes=uuid._generate_time_safe()[0]).node
     if val:
         val = val.to_bytes(6, byteorder=sys.byteorder)
         val = base64.urlsafe_b64encode(val)
@@ -254,6 +257,7 @@ def _saved_token(fpath, what, must_exist=None, read_only=False, node_tie=False):
                 if true_node
                 else "Saving"
             )
+            current_node = current_node or ""
             _debug("%s host ID: %s", action, current_node)
             if _write_attempt(False, npath, current_node, False) == WRITE_DEFER:
                 DEFERRED.append((False, npath, current_node, "Host ID"))

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,6 +41,7 @@ test:
     - anaconda_anon_usage.tokens
   commands:
     - pip check
+    - ANACONDA_ANON_USAGE_DEBUG=1 conda info
     - conda info | grep -q "user-agent.* aau/"
 
 about:

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -14,16 +14,18 @@ def test_client_token(aau_token_path):
 
 
 def test_client_token_no_nodeid(aau_token_path, mocker):
-    m1 = mocker.patch("uuid._unix_getnode")
+    m1 = mocker.patch("anaconda_anon_usage.utils._get_node_str")
     m1.return_value = None
-    m2 = mocker.patch("uuid._windll_getnode")
-    m2.return_value = None
+    node_path = aau_token_path + "_host"
+    assert not exists(aau_token_path) and not exists(node_path)
     token1 = tokens.client_token()
     assert token1 != "" and exists(aau_token_path)
     with open(aau_token_path) as fp:
         token2 = fp.read()
-    # No hostid saved in the token file
     assert token1 == token2, (token1, token2)
+    with open(node_path) as fp:
+        saved_node = fp.read()
+    assert not saved_node, saved_node
 
 
 def test_client_token_add_hostid(aau_token_path):


### PR DESCRIPTION
Supersedes #172 .

This Python 3.13 PR has implemented additional checks to make sure that the node value used in UUID generation is "stable":

https://github.com/python/cpython/pull/134704

I'm actually concerned that Python may be _too_ conservative here, and it has reduced the performance of `uuid.getnode()`, because Python 3.13 is falling back to subprocess-based node computation unnecessarily on my machine. And we don't want to do that for anaconda_anon_usage. So I have reimplemented `_get_node_str` so that it continues to use the faster computation approach.

I have also folded in the work of @naboyu in #172 . If the node string cannot be retrieved for some reason, then we are now writing out an empty string. This will avoid the exception that @naboyu was finding. I have updated the test `test_client_token_no_nodeid` to exercise this use case.