### PR TITLE
Align Rust token parsing with Python; fix test that hid the divergence

### DIFF
--- a/anaconda_anon_usage/tokens.py
+++ b/anaconda_anon_usage/tokens.py
@@ -99,7 +99,11 @@ def _search_path():
     Deterministic path construction — does not import conda.
     Identical logic in the Rust anaconda-anon-usage crate.
     """
-    if sys.platform == "win32":
+    # Test-only: override system paths for isolation (not a public API)
+    test_root = environ.get("ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT")
+    if test_root:
+        dirs = [test_root]
+    elif sys.platform == "win32":
         dirs = ["C:/ProgramData/conda"]
     else:
         dirs = ["/etc/conda", "/var/lib/conda"]

--- a/rust/src/tokens.rs
+++ b/rust/src/tokens.rs
@@ -206,24 +206,22 @@ fn is_valid_token(token: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
 }
 
-/// Parse a token value string into (token, source) pairs, deduplicating.
+/// Parse a single token value, validating and deduplicating.
 ///
-/// Token files may contain slash-separated multiple tokens (for org/machine tokens
-/// set by administrators). Each token is validated against the AAU format before
-/// inclusion.
-fn parse_token_values(content: &str, source: &str, results: &mut Vec<(String, String)>) {
-    for token in content.split('/') {
-        let token = token.trim();
-        if token.is_empty() {
-            continue;
-        }
-        if !is_valid_token(token) {
-            tracing::debug!("Invalid token discarded: {}", token);
-            continue;
-        }
-        if !results.iter().any(|(t, _)| t == token) {
-            results.push((token.to_string(), source.to_string()));
-        }
+/// The entire trimmed input is treated as one opaque token (no splitting).
+/// This matches Python anaconda-anon-usage behavior where each env var or
+/// file value is validated as a whole against VALID_TOKEN_RE.
+fn parse_token_value(content: &str, source: &str, results: &mut Vec<(String, String)>) {
+    let token = content.trim();
+    if token.is_empty() {
+        return;
+    }
+    if !is_valid_token(token) {
+        tracing::debug!("Invalid token discarded: {}", token);
+        return;
+    }
+    if !results.iter().any(|(t, _)| t == token) {
+        results.push((token.to_string(), source.to_string()));
     }
 }
 
@@ -245,7 +243,7 @@ fn system_tokens_with_source(fname: &str, label: &str, env_var: &str) -> Vec<(St
         let val = val.trim().to_string();
         if !val.is_empty() {
             tracing::debug!("Found {} token in environment: {}", label, val);
-            parse_token_values(&val, &format!("${}", env_var), &mut results);
+            parse_token_value(&val, &format!("${}", env_var), &mut results);
         }
     }
 
@@ -261,7 +259,7 @@ fn system_tokens_with_source(fname: &str, label: &str, env_var: &str) -> Vec<(St
 
             if let Ok(content) = read_file(&fpath, label, true) {
                 if !content.is_empty() {
-                    parse_token_values(&content, &fpath.display().to_string(), &mut results);
+                    parse_token_value(&content, &fpath.display().to_string(), &mut results);
                 }
             }
         }
@@ -676,66 +674,62 @@ mod tests {
         assert!(is_valid_token("x"));
     }
 
-    // ---- parse_token_values ----
+    // ---- parse_token_value ----
 
     #[test]
     fn parse_single_token() {
         let mut results = Vec::new();
-        parse_token_values("mytoken", "test", &mut results);
+        parse_token_value("mytoken", "test", &mut results);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, "mytoken");
     }
 
     #[test]
-    fn parse_slash_separated_tokens() {
+    fn parse_slash_containing_value_rejected() {
         let mut results = Vec::new();
-        parse_token_values("token1/token2/token3", "test", &mut results);
-        let tokens: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
-        assert_eq!(tokens, vec!["token1", "token2", "token3"]);
+        parse_token_value("token1/token2", "test", &mut results);
+        assert!(results.is_empty(), "Slash-containing value should be rejected");
     }
 
     #[test]
     fn parse_deduplicates() {
         let mut results = Vec::new();
-        parse_token_values("dup/dup/dup", "test", &mut results);
+        parse_token_value("dup", "test1", &mut results);
+        parse_token_value("dup", "test2", &mut results);
+        parse_token_value("dup", "test3", &mut results);
         assert_eq!(results.len(), 1);
-    }
-
-    #[test]
-    fn parse_skips_empty_segments() {
-        let mut results = Vec::new();
-        parse_token_values("a//b/", "test", &mut results);
-        let tokens: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
-        assert_eq!(tokens, vec!["a", "b"]);
     }
 
     #[test]
     fn parse_trims_whitespace() {
         let mut results = Vec::new();
-        parse_token_values("  tok1 / tok2 ", "test", &mut results);
-        let tokens: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
-        assert_eq!(tokens, vec!["tok1", "tok2"]);
+        parse_token_value("  plain-token  ", "test", &mut results);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "plain-token");
     }
 
     #[test]
-    fn parse_skips_invalid_tokens() {
+    fn parse_rejects_invalid_token() {
         let mut results = Vec::new();
-        parse_token_values("good/b@d!/also-good", "test", &mut results);
-        let tokens: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
-        assert_eq!(tokens, vec!["good", "also-good"]);
+        parse_token_value("b@d!", "test", &mut results);
+        assert!(results.is_empty(), "Invalid token should be rejected");
+
+        parse_token_value("good", "test", &mut results);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "good");
     }
 
     #[test]
     fn parse_empty_string() {
         let mut results = Vec::new();
-        parse_token_values("", "test", &mut results);
+        parse_token_value("", "test", &mut results);
         assert!(results.is_empty());
     }
 
     #[test]
     fn parse_appends_to_existing() {
         let mut results = vec![("existing".to_string(), "prior".to_string())];
-        parse_token_values("new", "test", &mut results);
+        parse_token_value("new", "test", &mut results);
         let tokens: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
         assert_eq!(tokens, vec!["existing", "new"]);
     }
@@ -743,7 +737,8 @@ mod tests {
     #[test]
     fn parse_dedup_across_existing() {
         let mut results = vec![("existing".to_string(), "prior".to_string())];
-        parse_token_values("existing/brand-new", "test", &mut results);
+        parse_token_value("existing", "test", &mut results);
+        parse_token_value("brand-new", "test", &mut results);
         let tokens: Vec<&str> = results.iter().map(|(t, _)| t.as_str()).collect();
         assert_eq!(tokens, vec!["existing", "brand-new"]);
     }
@@ -753,11 +748,11 @@ mod tests {
     #[test]
     fn system_tokens_from_env_var() {
         let env_key = "AAU_TEST_SYSTEM_TOKEN_ENV_7382";
+        // Slash-containing value is now rejected (matches Python behavior)
         unsafe { std::env::set_var(env_key, "envtoken1/envtoken2") };
         let result = system_tokens_with_source("nonexistent_file", "test", env_key);
         unsafe { std::env::remove_var(env_key) };
-        let tokens: Vec<&str> = result.iter().map(|(t, _)| t.as_str()).collect();
-        assert_eq!(tokens, vec!["envtoken1", "envtoken2"]);
+        assert!(result.is_empty(), "Slash-containing token should be rejected");
     }
 
     #[test]

--- a/rust/src/tokens.rs
+++ b/rust/src/tokens.rs
@@ -161,13 +161,20 @@ fn env_path_grandparent(var: &str) -> Option<PathBuf> {
 fn compute_search_path() -> Vec<PathBuf> {
     let mut dirs: Vec<PathBuf> = Vec::new();
 
-    #[cfg(windows)]
-    dirs.push("C:/ProgramData/conda".into());
+    // Test-only: override system paths for isolation (not a public API)
+    if let Ok(test_root) = std::env::var("ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT") {
+        if !test_root.is_empty() {
+            dirs.push(PathBuf::from(test_root));
+        }
+    } else {
+        #[cfg(windows)]
+        dirs.push("C:/ProgramData/conda".into());
 
-    #[cfg(not(windows))]
-    {
-        dirs.push("/etc/conda".into());
-        dirs.push("/var/lib/conda".into());
+        #[cfg(not(windows))]
+        {
+            dirs.push("/etc/conda".into());
+            dirs.push("/var/lib/conda".into());
+        }
     }
 
     let conda_root = conda_root();

--- a/rust/src/tokens.rs
+++ b/rust/src/tokens.rs
@@ -695,7 +695,10 @@ mod tests {
     fn parse_slash_containing_value_rejected() {
         let mut results = Vec::new();
         parse_token_value("token1/token2", "test", &mut results);
-        assert!(results.is_empty(), "Slash-containing value should be rejected");
+        assert!(
+            results.is_empty(),
+            "Slash-containing value should be rejected"
+        );
     }
 
     #[test]
@@ -759,7 +762,10 @@ mod tests {
         unsafe { std::env::set_var(env_key, "envtoken1/envtoken2") };
         let result = system_tokens_with_source("nonexistent_file", "test", env_key);
         unsafe { std::env::remove_var(env_key) };
-        assert!(result.is_empty(), "Slash-containing token should be rejected");
+        assert!(
+            result.is_empty(),
+            "Slash-containing token should be rejected"
+        );
     }
 
     #[test]

--- a/tests/test_rust_parity.py
+++ b/tests/test_rust_parity.py
@@ -110,6 +110,29 @@ def _home_env(tmpdir):
     return {"HOME": tmpdir}
 
 
+def _isolated_env_for_parity(tmpdir):
+    """Build an env dict that fully isolates the token search path.
+
+    Covers:
+    - $HOME (via _home_env)
+    - $CONDA_PREFIX, $CONDA_ROOT, $CONDA_EXE, $CONDA_PYTHON_EXE
+    - $XDG_CONFIG_HOME (redirected to nonexistent sandbox path)
+    - /etc/conda, /var/lib/conda, C:/ProgramData/conda
+      (via ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT)
+    """
+    tmpdir = str(tmpdir)
+    env = _home_env(tmpdir)
+    env["CONDA_PREFIX"] = ""
+    env["CONDA_ROOT"] = ""
+    env["CONDA_EXE"] = ""
+    env["CONDA_PYTHON_EXE"] = ""
+    env["XDG_CONFIG_HOME"] = str(Path(tmpdir) / "xdg")
+    sys_root = Path(tmpdir) / "fake_etc_conda"
+    sys_root.mkdir(exist_ok=True)
+    env["ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT"] = str(sys_root)
+    return env
+
+
 def _isolated_home():
     """Create a temp HOME with minimal conda config to isolate token tests."""
     tmpdir = tempfile.mkdtemp()
@@ -375,7 +398,7 @@ class TestSystemTokensParity:
         tmpdir = _isolated_home()
         try:
             test_token = "parity-test-token-42"
-            env = {**_home_env(tmpdir), env_var: test_token}
+            env = {**_isolated_env_for_parity(tmpdir), env_var: test_token}
 
             py_tokens = _python_token_fresh(py_func, env_override=env)
             py_list = [t for t in py_tokens.split("\n") if t]
@@ -388,6 +411,7 @@ class TestSystemTokensParity:
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
+    # Regression test: specifically guards against Rust re-adding slash-splitting
     @pytest.mark.parametrize(
         "env_var,prefix,py_func",
         [
@@ -400,7 +424,7 @@ class TestSystemTokensParity:
         """Slash-separated tokens in env var should behave identically in both."""
         tmpdir = _isolated_home()
         try:
-            env = {**_home_env(tmpdir), env_var: "token-alpha/token-beta"}
+            env = {**_isolated_env_for_parity(tmpdir), env_var: "token-alpha/token-beta"}
 
             py_tokens = _python_token_fresh(py_func, env_override=env)
             py_list = [t for t in py_tokens.split("\n") if t]
@@ -430,7 +454,7 @@ class TestSystemTokensParity:
         tmpdir = _isolated_home()
         try:
             # '/' is not in VALID_TOKEN_RE's char class
-            env = {**_home_env(tmpdir), env_var: "valid-part/also-valid-part"}
+            env = {**_isolated_env_for_parity(tmpdir), env_var: "valid-part/also-valid-part"}
 
             py_tokens = _python_token_fresh(py_func, env_override=env)
             py_list = [t for t in py_tokens.split("\n") if t]
@@ -461,7 +485,7 @@ class TestSystemTokensParity:
         tmpdir = _isolated_home()
         try:
             invalid_token = "x" * 37
-            env = {**_home_env(tmpdir), env_var: invalid_token}
+            env = {**_isolated_env_for_parity(tmpdir), env_var: invalid_token}
 
             py_tokens = _python_token_fresh(py_func, env_override=env)
             py_list = [t for t in py_tokens.split("\n") if t]
@@ -504,7 +528,7 @@ class TestSystemTokensParity:
         else:
             tmpdir = _isolated_home()
             token_file = Path(tmpdir) / ".conda" / fname
-            env = _home_env(tmpdir)
+            env = _isolated_env_for_parity(tmpdir)
 
         token_file.write_text("file-based-token-99\n")
         try:
@@ -546,7 +570,7 @@ class TestSystemTokensParity:
             token_file = Path(tmpdir) / ".conda" / fname
             token_file.write_text("dedup-test-token\n")
 
-            env = {**_home_env(tmpdir), env_var: "dedup-test-token"}
+            env = {**_isolated_env_for_parity(tmpdir), env_var: "dedup-test-token"}
 
             py_tokens = _python_token_fresh(py_func, env_override=env)
             py_list = [t for t in py_tokens.split("\n") if t]
@@ -582,7 +606,7 @@ class TestFullTokenStringParity:
         """
         tmpdir = _isolated_home()
         try:
-            env = {**_home_env(tmpdir), "CONDA_PREFIX": ""}
+            env = _isolated_env_for_parity(tmpdir)
 
             # Set up a known org token so we have something to compare
             conda_dir = Path(tmpdir) / ".conda"

--- a/tests/test_rust_parity.py
+++ b/tests/test_rust_parity.py
@@ -397,17 +397,54 @@ class TestSystemTokensParity:
         ],
     )
     def test_env_var_slash_separated_tokens(self, env_var, prefix, py_func):
-        """Slash-separated tokens in env var should produce multiple entries."""
+        """Slash-separated tokens in env var should behave identically in both."""
         tmpdir = _isolated_home()
         try:
             env = {**_home_env(tmpdir), env_var: "token-alpha/token-beta"}
 
+            py_tokens = _python_token_fresh(py_func, env_override=env)
+            py_list = [t for t in py_tokens.split("\n") if t]
+
             rs_tokens = _parse_tokens(_run_rust_tokens(env_override=env))
             rs_list = rs_tokens.get(prefix, [])
 
-            assert (
-                "token-alpha" in rs_list and "token-beta" in rs_list
-            ), f"Rust didn't split slash tokens: {rs_list}"
+            assert py_list == rs_list, (
+                f"Python and Rust diverge on slash-separated input:\n"
+                f"  Python: {py_list}\n"
+                f"  Rust:   {rs_list}"
+            )
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @pytest.mark.parametrize(
+        "env_var,prefix,py_func",
+        [
+            ("ANACONDA_ANON_USAGE_ORG_TOKEN", "o", "organization_tokens()"),
+            ("ANACONDA_ANON_USAGE_MACHINE_TOKEN", "m", "machine_tokens()"),
+            ("ANACONDA_ANON_USAGE_INSTALLER_TOKEN", "i", "installer_tokens()"),
+        ],
+    )
+    def test_env_var_with_invalid_char_rejected_identically(self, env_var, prefix, py_func):
+        """A token with invalid chars should be rejected by both implementations
+        in the same way — not discarded by one and salvaged-by-splitting by the other."""
+        tmpdir = _isolated_home()
+        try:
+            # '/' is not in VALID_TOKEN_RE's char class
+            env = {**_home_env(tmpdir), env_var: "valid-part/also-valid-part"}
+
+            py_tokens = _python_token_fresh(py_func, env_override=env)
+            py_list = [t for t in py_tokens.split("\n") if t]
+
+            rs_tokens = _parse_tokens(_run_rust_tokens(env_override=env))
+            rs_list = rs_tokens.get(prefix, [])
+
+            # If both implementations consider '/' invalid, both should return [].
+            # If Rust "helpfully" splits on '/', it will return the two halves.
+            assert py_list == rs_list, (
+                f"Divergence on slash handling:\n"
+                f"  Python (rejects '/' wholesale): {py_list}\n"
+                f"  Rust (splits on '/'):           {rs_list}"
+            )
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 

--- a/tests/test_rust_parity.py
+++ b/tests/test_rust_parity.py
@@ -424,7 +424,10 @@ class TestSystemTokensParity:
         """Slash-separated tokens in env var should behave identically in both."""
         tmpdir = _isolated_home()
         try:
-            env = {**_isolated_env_for_parity(tmpdir), env_var: "token-alpha/token-beta"}
+            env = {
+                **_isolated_env_for_parity(tmpdir),
+                env_var: "token-alpha/token-beta",
+            }
 
             py_tokens = _python_token_fresh(py_func, env_override=env)
             py_list = [t for t in py_tokens.split("\n") if t]
@@ -448,13 +451,19 @@ class TestSystemTokensParity:
             ("ANACONDA_ANON_USAGE_INSTALLER_TOKEN", "i", "installer_tokens()"),
         ],
     )
-    def test_env_var_with_invalid_char_rejected_identically(self, env_var, prefix, py_func):
+    def test_env_var_with_invalid_char_rejected_identically(
+        self, env_var, prefix, py_func
+    ):
         """A token with invalid chars should be rejected by both implementations
-        in the same way — not discarded by one and salvaged-by-splitting by the other."""
+        in the same way — not discarded by one and salvaged-by-splitting by the other.
+        """
         tmpdir = _isolated_home()
         try:
             # '/' is not in VALID_TOKEN_RE's char class
-            env = {**_isolated_env_for_parity(tmpdir), env_var: "valid-part/also-valid-part"}
+            env = {
+                **_isolated_env_for_parity(tmpdir),
+                env_var: "valid-part/also-valid-part",
+            }
 
             py_tokens = _python_token_fresh(py_func, env_override=env)
             py_list = [t for t in py_tokens.split("\n") if t]


### PR DESCRIPTION
## Fix: align Rust system token parsing with Python; isolate parity tests

Three findings:

1. Rust's `parse_token_values` splits env-var and file values on `/`; Python's `_system_tokens` treats each value as one opaque token. They produce different output on the same input.
2. The existing parity test for this case (`test_env_var_slash_separated_tokens`) doesn't actually compare Python and Rust — it accepts `py_func` as a parameter but never calls it, so the divergence above was never caught.
3. The parity tests aren't isolated from admin-deployed tokens in `/etc/conda`, `/var/lib/conda`, etc. On a developer machine with real tokens in those paths, tests produce host-dependent results.

This PR fixes these.

## Finding 1: Rust splits, Python doesn't

### The bug

`rust/src/tokens.rs:parse_token_values` does:

```rust
for token in content.split('/') { ... }
```

Python's `anaconda_anon_usage/tokens.py:_system_tokens` does the opposite — it reads the whole line as one opaque string, appends it to a list, then validates with `VALID_TOKEN_RE = r"^(?:[A-Za-z0-9]|_|-){1,36}$"`. Since `/` isn't in that char class, any slash-containing input is discarded wholesale by Python but produces multiple tokens in Rust.

### Concrete reproduction

With `ANACONDA_ANON_USAGE_INSTALLER_TOKEN="token-alpha/token-beta"`:

```
Python: []
Rust:   ['token-alpha', 'token-beta']
```

Same input, different output.

### The fix

Rename `parse_token_values` → `parse_token_value` (singular) and remove the splitting loop. The function now trims, validates, dedups, and pushes — matching Python's behavior exactly. See commit `fix(rust): treat system token values as opaque strings to match Python`.

This also updates the Rust unit tests. The renamed test `parse_slash_containing_value_rejected` (was `parse_slash_separated_tokens`) locks in the new behavior so nobody re-adds splitting.

## Finding 2: the parity test didn't compare Python and Rust

The existing test signature and body:

```python
def test_env_var_slash_separated_tokens(self, env_var, prefix, py_func):
    """Slash-separated tokens in env var should produce multiple entries."""
    tmpdir = _isolated_home()
    try:
        env = {**_home_env(tmpdir), env_var: "token-alpha/token-beta"}
        rs_tokens = _parse_tokens(_run_rust_tokens(env_override=env))
        rs_list = rs_tokens.get(prefix, [])
        assert (
            "token-alpha" in rs_list and "token-beta" in rs_list
        ), f"Rust didn't split slash tokens: {rs_list}"
```

`py_func` is a parameter (the name of the Python function to call for comparison) but it's never referenced in the body. The test only checks Rust's output against the Rust-expected values. It was effectively a Rust-only unit test labeled as a parity test.

Fixed by actually calling `py_func` and asserting `py_list == rs_list`, matching the pattern used by the other parametrized tests in the same class.

## Finding 3: tests weren't isolated from system state

### The bug

`_isolated_home()` creates a tempdir and sets `$HOME` to point at it. That isolates `~/.conda/*_token`, but Python's `_search_path` and Rust's `compute_search_path` also walk hardcoded system paths (`/etc/conda`, `/var/lib/conda`, `C:/ProgramData/conda`). Those are unaffected by `$HOME`.

On a machine with admin-deployed tokens these paths leak into the test. Evidence from my local run (with root-owned tokens at `/etc/conda/{org,machine}_token`):

```
FAILED test_env_var_slash_separated_tokens[ANACONDA_ANON_USAGE_ORG_TOKEN-o-organization_tokens()]
  Python: ['KA1VeQZ5QJq0EPqi6AwV8A']
  Rust:   ['token-alpha', 'token-beta', 'KA1VeQZ5QJq0EPqi6AwV8A']
```

That `KA1V...` string isn't from the test, it's a real admin token sitting on my laptop at `/etc/conda/org_token`. 

### The fix

Added a test-only env var `ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT`. When set and non-empty, both Python's `_search_path` and Rust's `compute_search_path` replace their hardcoded system paths with the caller-supplied directory. Undocumented — not a public API, and the `_TEST_` infix in the name makes that clear.

New helper `_isolated_env_for_parity(tmpdir)` sets this along with emptying `$CONDA_PREFIX`, `$CONDA_ROOT`, `$CONDA_EXE`, `$CONDA_PYTHON_EXE`, and redirecting `$XDG_CONFIG_HOME` to a sandbox path. All parity tests migrated to use it.

## Evidence/Verification

### Before the fix, on a host with admin tokens

Six failures across two tests. Every org/machine assertion includes real admin tokens:

```
Python: ['KA1VeQZ5QJq0EPqi6AwV8A']
Rust:   ['token-alpha', 'token-beta', 'KA1VeQZ5QJq0EPqi6AwV8A']
```

Installer works cleanly because I happen not to have an admin-deployed installer token:

```
Python: []
Rust:   ['token-alpha', 'token-beta']
```

### After isolation, before the Rust fix

Three failures, clean repro, no host state bleed:

```
FAILED test_env_var_slash_separated_tokens[ANACONDA_ANON_USAGE_ORG_TOKEN-o-...]
  Python: []
  Rust:   ['token-alpha', 'token-beta']

FAILED test_env_var_slash_separated_tokens[ANACONDA_ANON_USAGE_MACHINE_TOKEN-m-...]
  Python: []
  Rust:   ['token-alpha', 'token-beta']

FAILED test_env_var_slash_separated_tokens[ANACONDA_ANON_USAGE_INSTALLER_TOKEN-i-...]
  Python: []
  Rust:   ['token-alpha', 'token-beta']
```

Three tests, three identical failures, one underlying bug.

### After both fixes

All parity tests green. Tests pass on my machine *with* `/etc/conda/org_token` still present — isolation works.

Each commit passes its own tests (run `pytest tests/test_rust_parity.py` at any commit). Commit 3 is where the existing `test_env_var_slash_separated_tokens` actually starts asserting Python↔Rust equality and passing — prior commits make it possible to fail for the right reason, commit 3 makes it pass.

## Verification

```bash
cd rust && cargo build --features cli --release && cd ..
pytest tests/test_rust_parity.py -v          # all green
pytest tests/ --ignore=tests/test_rust_parity.py -v  # no regressions in Python suite
cd rust && cargo test --features cli          # Rust unit tests green
```