### PR TITLE
Harden parity test isolation: Cargo feature gate + env allowlist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,15 +37,21 @@ jobs:
     - name: Check formatting
       working-directory: rust
       run: cargo fmt --check
-    - name: Run clippy
+    - name: Run clippy (release feature set)
       working-directory: rust
       run: cargo clippy --features cli -- -D warnings
-    - name: Run tests
+    - name: Run clippy (with test-support)
+      working-directory: rust
+      run: cargo clippy --features cli,test-support -- -D warnings
+    - name: Run tests (release feature set, verifies test-support is properly gated)
       working-directory: rust
       run: cargo test --features cli --verbose
-    - name: Build release binary
+    - name: Run tests (with test-support)
       working-directory: rust
-      run: cargo build --features cli --release
+      run: cargo test --features cli,test-support --verbose
+    - name: Build release binary (with test-support for parity tests)
+      working-directory: rust
+      run: cargo build --features cli,test-support --release
     - name: Upload Rust binary
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,9 @@ rattler = []
 # Signal that reqwest is present in the consuming workspace.
 # build.rs extracts the version from Cargo.lock; no dependency added.
 reqwest = []
+# Enable test-only overrides (e.g. ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT).
+# Must NEVER be enabled in released binaries.
+test-support = []
 
 [[bin]]
 name = "anaconda-anon-usage"

--- a/rust/src/tokens.rs
+++ b/rust/src/tokens.rs
@@ -161,11 +161,17 @@ fn env_path_grandparent(var: &str) -> Option<PathBuf> {
 fn compute_search_path() -> Vec<PathBuf> {
     let mut dirs: Vec<PathBuf> = Vec::new();
 
-    // Test-only: override system paths for isolation (not a public API)
-    if let Ok(test_root) = std::env::var("ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT") {
-        if !test_root.is_empty() {
-            dirs.push(PathBuf::from(test_root));
-        }
+    // Test-only override, gated at compile time by the `test-support` feature.
+    // Released binaries never see this code path.
+    #[cfg(feature = "test-support")]
+    let test_root = std::env::var("ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT")
+        .ok()
+        .filter(|v| !v.is_empty());
+    #[cfg(not(feature = "test-support"))]
+    let test_root: Option<String> = None;
+
+    if let Some(test_root) = test_root {
+        dirs.push(PathBuf::from(test_root));
     } else {
         #[cfg(windows)]
         dirs.push("C:/ProgramData/conda".into());
@@ -1109,5 +1115,52 @@ mod tests {
         for e in &entries[..aau_idx] {
             assert_eq!(e.label, "platform");
         }
+    }
+
+    // ---- test-support feature gating ----
+    // The `test-support` feature must never be enabled in released binaries.
+    // These tests lock in the observable behavior of the gating in both directions.
+
+    #[cfg(feature = "test-support")]
+    #[test]
+    fn system_root_override_honored_with_test_support() {
+        let tmp = tempfile::tempdir().unwrap();
+        let override_path = tmp.path().to_path_buf();
+        unsafe {
+            std::env::set_var("ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT", &override_path);
+        }
+        let search_path = compute_search_path();
+        unsafe {
+            std::env::remove_var("ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT");
+        }
+        assert!(
+            search_path.contains(&override_path),
+            "with test-support, override path should appear in search path"
+        );
+        // And the real system dirs should NOT be included when the override is active
+        assert!(
+            !search_path.iter().any(|p| p == &PathBuf::from("/etc/conda")
+                || p == &PathBuf::from("/var/lib/conda")
+                || p == &PathBuf::from("C:/ProgramData/conda")),
+            "override should replace system dirs, not append to them"
+        );
+    }
+
+    #[cfg(not(feature = "test-support"))]
+    #[test]
+    fn system_root_override_ignored_without_test_support() {
+        let tmp = tempfile::tempdir().unwrap();
+        let override_path = tmp.path().to_path_buf();
+        unsafe {
+            std::env::set_var("ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT", &override_path);
+        }
+        let search_path = compute_search_path();
+        unsafe {
+            std::env::remove_var("ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT");
+        }
+        assert!(
+            !search_path.contains(&override_path),
+            "without test-support, override path MUST NOT appear in search path"
+        );
     }
 }

--- a/tests/test_rust_parity.py
+++ b/tests/test_rust_parity.py
@@ -44,16 +44,49 @@ def _find_rust_bin() -> str:
 RUST_BIN = _find_rust_bin()
 
 
-def _run_rust(args, env_override=None):
-    """Run the Rust binary with the given arguments."""
-    env = os.environ.copy()
+# Env vars that must be passed through to subprocesses for them to function at all.
+# On POSIX only PATH is really needed; Windows needs its own minimum set or Python
+# and the Rust binary will fail to initialize.
+_SUBPROCESS_ENV_ALLOWLIST = (
+    "PATH",
+    # Windows essentials — subprocess/Python break without these
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "WINDIR",
+    "TEMP",
+    "TMP",
+    "PATHEXT",
+    "COMSPEC",
+    "PROCESSOR_ARCHITECTURE",
+    # macOS/Linux Rust binaries dlopen/link against system libs reachable via these
+    "DYLD_LIBRARY_PATH",
+    "LD_LIBRARY_PATH",
+)
+
+
+def _subprocess_env(env_override=None):
+    """Build a subprocess env from a small allowlist, then apply overrides.
+
+    Nothing from the caller's environment leaks in unless it's on the allowlist.
+    Callers use env_override to add exactly what each test needs.
+    """
+    env = {}
+    for key in _SUBPROCESS_ENV_ALLOWLIST:
+        val = os.environ.get(key)
+        if val is not None:
+            env[key] = val
     if env_override:
         env.update(env_override)
+    return env
+
+
+def _run_rust(args, env_override=None):
+    """Run the Rust binary with the given arguments."""
     result = subprocess.run(
         [RUST_BIN] + args,
         capture_output=True,
         text=True,
-        env=env,
+        env=_subprocess_env(env_override),
     )
     assert (
         result.returncode == 0
@@ -81,9 +114,6 @@ def _parse_tokens(token_string):
 
 def _python_token_fresh(func_name, env_override=None):
     """Run a Python AAU token function in a fresh subprocess to avoid caching."""
-    env = os.environ.copy()
-    if env_override:
-        env.update(env_override)
     code = f"""
 import os, sys
 from anaconda_anon_usage import tokens
@@ -93,11 +123,17 @@ if isinstance(result, list):
 elif result is not None:
     print(result)
 """
+    # Python needs to locate the anaconda_anon_usage package — inherit PYTHONPATH
+    # and the currently-active venv/prefix so imports resolve the same interpreter.
+    py_env = _subprocess_env(env_override)
+    for key in ("PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV"):
+        if key in os.environ and key not in py_env:
+            py_env[key] = os.environ[key]
     result = subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
-        env=env,
+        env=py_env,
     )
     assert result.returncode == 0, f"Python {func_name} failed: {result.stderr}"
     return result.stdout.strip()
@@ -113,20 +149,15 @@ def _home_env(tmpdir):
 def _isolated_env_for_parity(tmpdir):
     """Build an env dict that fully isolates the token search path.
 
-    Covers:
-    - $HOME (via _home_env)
-    - $CONDA_PREFIX, $CONDA_ROOT, $CONDA_EXE, $CONDA_PYTHON_EXE
-    - $XDG_CONFIG_HOME (redirected to nonexistent sandbox path)
-    - /etc/conda, /var/lib/conda, C:/ProgramData/conda
-      (via ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT)
+    With the subprocess env built from a strict allowlist (see _subprocess_env),
+    unknown env vars can't leak in. This helper only has to set the positive
+    values each implementation needs:
+    - $HOME (platform-aware, via _home_env)
+    - ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT — overrides /etc/conda, /var/lib/conda,
+      C:/ProgramData/conda in both Python and Rust implementations
     """
     tmpdir = str(tmpdir)
     env = _home_env(tmpdir)
-    env["CONDA_PREFIX"] = ""
-    env["CONDA_ROOT"] = ""
-    env["CONDA_EXE"] = ""
-    env["CONDA_PYTHON_EXE"] = ""
-    env["XDG_CONFIG_HOME"] = str(Path(tmpdir) / "xdg")
     sys_root = Path(tmpdir) / "fake_etc_conda"
     sys_root.mkdir(exist_ok=True)
     env["ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT"] = str(sys_root)


### PR DESCRIPTION
## Summary

Follow-up to #222. Two independent hardening improvements to the parity test isolation strategy, both patterns lifted from anaconda-config-rs's approach to the same problem.

### 1. Gate the Rust override behind a Cargo `test-support` feature

Before: `ANACONDA_ANON_USAGE_TEST_SYSTEM_ROOT` lived in the production code path on both sides. The `_TEST_` infix was convention-only — nothing prevented the env var from being set in a user's environment and silently masking real admin tokens.

After: The env var is read only under `#[cfg(feature = "test-support")]`. Released binaries (`cargo build --features cli`) do not compile the override in at all. Parity tests build with `--features cli,test-support` to re-enable it.

Two new unit tests lock this in:
- `system_root_override_honored_with_test_support` — runs only with the feature, asserts the override replaces system dirs
- `system_root_override_ignored_without_test_support` — runs only without the feature, asserts the env var has no effect on the search path

CI now runs the full test suite in **both** configurations, so the gated-out behavior stays covered.

Python side: no compile-time equivalent exists, so the runtime check remains. The `_TEST_` infix is sufficient self-documentation on that side.

### 2. Allowlist env vars in test subprocesses, don't deny-list

Before: `_run_rust`, `_run_rust_tokens`, and `_python_token_fresh` all did `env = os.environ.copy()`, then `_isolated_env_for_parity` cleared a known set of vars (`CONDA_PREFIX`, `CONDA_ROOT`, `CONDA_EXE`, `CONDA_PYTHON_EXE`, `XDG_CONFIG_HOME`). Works today, but any new `CONDA_*` or `ANACONDA_*` env var introduced elsewhere in the codebase silently leaks in until someone remembers to extend the list.

After: `_subprocess_env()` builds from a strict allowlist (`PATH`, Windows essentials like `SYSTEMROOT`/`SYSTEMDRIVE`/`WINDIR`/`TEMP`/`PATHEXT`, and `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH` for Rust binary linking). Nothing else inherits unless callers explicitly pass it via `env_override`. `_python_token_fresh` additionally propagates `PYTHONPATH`/`PYTHONHOME`/`VIRTUAL_ENV` so the subprocess can import `anaconda_anon_usage`.

`_isolated_env_for_parity` is now three lines instead of ten — the explicit clears of `CONDA_PREFIX` etc. aren't needed when nothing is inherited in the first place.

## Test plan

- [x] All 39 existing Python unit tests pass locally
- [x] 32 of 33 parity tests pass locally (the one failure is an unrelated versioneer `.dirty` mismatch caused by having uncommitted changes — will self-resolve in CI)
- [x] `cargo test --features cli` passes (71 tests) — gating test for the without-test-support case runs
- [x] `cargo test --features cli,test-support` passes (71 tests) — gating test for the with-test-support case runs
- [x] `cargo clippy` passes cleanly in both feature configurations
- [x] Pre-commit hooks pass (rustfmt + clippy included)
- [ ] CI matrix runs against both Rust build configurations and all conda versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
