### PR TITLE
fix: treat empty env prefix as absent in Rust `resolve_prefix`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - main
+      - feat/rust-crate
 
 concurrency:
   # Concurrency group that uses the workflow name and PR number if available

--- a/rust/README.md
+++ b/rust/README.md
@@ -343,6 +343,14 @@ rust/
   tokens are prepended before `aau/` and do not affect parity with Python
   for the core AAU token types.
 
+- **Legacy token file format**: Older Python installs (pre-0.8) wrote the
+  `aau_token` file as a single line `"{token} {host_id}"` (space-separated).
+  The Rust crate does not parse that format — it expects a bare token on
+  the first line and a separate `aau_token_host` file for the host ID.
+  In practice this matters only on upgrade paths where a machine still
+  carries a pre-0.8 token file; in that case Rust will reject the malformed
+  token and regenerate, producing a new `c/` token value on first use.
+
 - **Deferred write lifecycle**: The Python package registers
   `_final_attempt()` via `atexit.register(...)` at import time, so any
   deferred token write is flushed automatically when the interpreter exits.

--- a/rust/src/tokens.rs
+++ b/rust/src/tokens.rs
@@ -302,12 +302,18 @@ fn session_token() -> Result<String> {
     cached_string("session_token", || random_token("session"))
 }
 
-/// Resolve the environment prefix: explicit arg > global > CONDA_PREFIX > None.
+/// Resolve the environment prefix: explicit arg > global > `$CONDA_PREFIX` > None.
+///
+/// An empty string at any layer is treated as absent, matching Python's
+/// `environment_token("")` behavior (fixed in #224, Bug 9). Without this,
+/// a caller-supplied `Config::env_prefix = Some("")` or CLI `--env-prefix ""`
+/// would resolve `etc/aau_token` against the process cwd — the same relative
+/// path bug the Python side was hardened against.
 fn resolve_prefix(prefix: Option<&str>) -> Option<String> {
-    if let Some(p) = prefix {
+    if let Some(p) = prefix.filter(|s| !s.is_empty()) {
         return Some(p.to_string());
     }
-    if let Some(p) = crate::get_env_prefix() {
+    if let Some(p) = crate::get_env_prefix().filter(|s| !s.is_empty()) {
         return Some(p);
     }
     std::env::var("CONDA_PREFIX").ok().filter(|s| !s.is_empty())

--- a/tests/test_rust_parity.py
+++ b/tests/test_rust_parity.py
@@ -826,6 +826,53 @@ class TestBugFixParity:
             f"stdout={result.stdout!r} stderr={result.stderr!r}"
         )
 
+    # Rust's resolve_prefix previously passed an empty explicit prefix through
+    # as Some(""), so environment_token would compute `"".join("etc",
+    # "aau_token")` → the relative path `etc/aau_token`. Python's #224 Bug 9
+    # commit described the target behavior as "matching Rust's resolve_prefix()
+    # which treats an empty CONDA_PREFIX as absent" — but that filter only
+    # applied to the CONDA_PREFIX fallback branch, not to an explicit Some("")
+    # from Config::env_prefix / set_env_prefix / --env-prefix "". The fix
+    # applies the same empty-string filter to all three resolution layers.
+    def test_rust_skips_environment_token_when_prefix_empty(self):
+        """Rust --env-prefix '' must emit no e/ token (not a cwd-relative read).
+
+        Reproduction: a token file at `<cwd>/etc/aau_token` that *would* pass
+        validation. Before the fix, Rust would read it and emit an e/ token
+        sourced from the literal path "/etc/aau_token". After the fix, the
+        empty prefix is treated as absent and no e/ token is emitted.
+
+        FIXED in:
+          - rust/src/tokens.rs :: resolve_prefix (filter Some("") on all layers)
+        """
+        tmpdir = tempfile.mkdtemp()
+        try:
+            etc_dir = Path(tmpdir) / "etc"
+            etc_dir.mkdir()
+            # Any valid-looking token; the bug is that Rust reads the file at
+            # all, not what it contains.
+            (etc_dir / "aau_token").write_text("cwdrelative-token-abcdefg\n")
+
+            # Run Rust from inside tmpdir so a cwd-relative read would find
+            # the token file. The empty --env-prefix must take precedence
+            # over both the global setter (unset here) and $CONDA_PREFIX
+            # (explicitly cleared via the subprocess allowlist).
+            result = subprocess.run(
+                [RUST_BIN, "--env-prefix", ""],
+                capture_output=True,
+                text=True,
+                env=_subprocess_env(_home_env(tmpdir)),
+                cwd=tmpdir,
+            )
+            assert result.returncode == 0, f"Rust binary failed: {result.stderr}"
+            rs_tokens = _parse_tokens(result.stdout.strip())
+            assert "e" not in rs_tokens, (
+                "Rust emitted an e/ token from an empty --env-prefix — likely "
+                f"read cwd-relative etc/aau_token: {rs_tokens.get('e')}"
+            )
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
 
 class TestFileFormatEdgeCases:
     """File-format edge cases for _read_file / read_file on both sides."""


### PR DESCRIPTION
Follow-up to #224. An additional parity gap surfaced while verifying #224's Bug 9 fix on the Rust side.

### Empty env prefix resolves to a cwd-relative path

**FIX (Rust):** `rust/src/tokens.rs` — `resolve_prefix()`

Before, `resolve_prefix(Some(""))` returned `Some("")` unchanged, so `environment_token` would compute `"".join("etc", "aau_token")` and read `etc/aau_token` relative to the process cwd. Reproducible via `anaconda-anon-usage --env-prefix ""` from a directory containing `etc/aau_token` with a valid-looking token — Rust would emit an `e/` entry sourced from the literal path `/etc/aau_token` that was in fact `<cwd>/etc/aau_token`.

After, empty strings are filtered on all three resolution layers (`Config::env_prefix` / `set_env_prefix` / `$CONDA_PREFIX`), matching Python's `environment_token("")` short-circuit from #224 Bug 9.

#224's commit message described the target as "matching Rust's `resolve_prefix()` behavior which treats an empty `CONDA_PREFIX` as absent" — true for the `$CONDA_PREFIX` branch (via `.filter(|s| !s.is_empty())`) but not for an explicit `Some("")` from the caller-facing layers. This commit closes that gap.

### Documentation: legacy token file format

**FIX (docs):** `rust/README.md` — Known divergences section

The inline doc comment in `utils.rs::saved_token` already noted that the Rust crate does not parse the pre-0.8 Python format (`"{token} {host_id}"` on one line). Promote that note to the user-facing Known divergences section so upgraders from the pre-0.8 Python package know to expect a new `c/` value on first use with the Rust binary.

### CI: run full test matrix on `feat/rust-crate` PRs

**FIX (CI):** `.github/workflows/main.yml`

The `Build` workflow's `pull_request` trigger was limited to PRs whose base is `main`, so every PR in the `feat/rust-crate` series (#222–#225, and originally this one) only got the `pre-commit / check` job. The full Rust matrix (fmt/clippy/test on three OSes), the conda build, and the 10-conda-version × 5-OS `test` matrix (including the Rust parity suite) were all skipped.

That silence is what let the empty-`--env-prefix` divergence reach `feat/rust-crate` unnoticed. Adding `feat/rust-crate` to the branches filter restores full coverage on the integration branch's PRs while keeping `main` as the other gate. No additional CI spend on `main` PRs.

## Parity tests (new, in `tests/test_rust_parity.py`)

Class `TestBugFixParity`:

- `test_rust_skips_environment_token_when_prefix_empty` — runs the Rust binary from a tmpdir containing a valid `etc/aau_token`, with `--env-prefix ""`, and asserts no `e/` token is emitted. Fails before the fix (Rust reads the cwd-relative file and emits `e/cwdrelative-token-abcdefg`); passes after.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes in both `cli` and `cli,test-support` configs
- [x] `cargo test` passes in both configs (71 tests)
- [x] `pytest tests/test_rust_parity.py` — 60/61 pass; the one failure is the unrelated versioneer `.dirty` mismatch from uncommitted changes that self-resolves in CI (per #225's test plan)
- [ ] CI: this PR is the first to exercise the full matrix on `feat/rust-crate` — results will be visible once the workflow runs

---

Stacked on top of this: #227 (Rust idiom refactors).