### PR TITLE
feat: split token_string into platform_ua_string + identity_tokens

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -96,7 +96,7 @@ fn main() {
         ..Default::default()
     };
 
-    // Full token string (for User-Agent headers)
+    // Full token string (for User-Agent headers at Anaconda-operated domains)
     let ua = token_string(&config);
 
     // Per-token details (for diagnostics)
@@ -105,6 +105,39 @@ fn main() {
     }
 }
 ```
+
+### Non-identifying UA for non-Anaconda domains
+
+The full `token_string` contains identity-bearing tokens (`c/`, `s/`, `e/`,
+`a/`, `i/`, `o/`, `m/`) that should only be sent to Anaconda-operated
+domains. For requests to PyPI, GitHub, or other third-party hosts, use
+`platform_ua_string` instead — it contains only the non-identifying
+portion: host-tool prefix, platform info, and rattler/reqwest versions.
+
+```rust
+use anaconda_anon_usage::{Config, PlatformUaConfig, platform_ua_string, token_string};
+
+let config = Config {
+    prefix: Some("ana/0.1.0".into()),
+    platform: true,
+    ..Default::default()
+};
+
+// Safe to send to any domain:
+let non_identifying = platform_ua_string(&(&config).into());
+// e.g. "ana/0.1.0 Darwin/25.2.0 OSX/26.2 rustc/1.82.0"
+
+// Send to Anaconda-operated domains only:
+let full = token_string(&config);
+// e.g. "ana/0.1.0 Darwin/25.2.0 OSX/26.2 rustc/1.82.0 aau/0.8.0 c/... s/..."
+```
+
+`platform_ua_string`'s result is cached per-`PlatformUaConfig` for the
+process lifetime, so repeated calls during HTTP client construction are
+effectively free.
+
+`identity_tokens(&config)` is available for callers that need just the
+identity portion separately (e.g., middleware that composes its own UA).
 
 ### Platform and prefix tokens
 
@@ -306,7 +339,7 @@ rust/
   Cargo.toml
   build.rs          # Version from git describe; rustc/rattler/reqwest version extraction
   src/
-    lib.rs          # Public API: Config, token_string(), token_details(), init(), FlushGuard, set_env_prefix(), get_env_prefix()
+    lib.rs          # Public API: Config, PlatformUaConfig, token_string(), platform_ua_string(), identity_tokens(), token_details(), init(), FlushGuard, set_env_prefix(), get_env_prefix()
     tokens.rs       # Token collection, JWT parsing, search paths, caching
     utils.rs        # File I/O, random_token(), saved_token(), deferred writes
     platform.rs     # Platform detection: kernel, OS distro, libc, rustc version

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,18 @@
 //!
 //! `[prefix...] [platform...] aau/{version} c/{client} s/{session} e/{env} [a/{cloud}] [o/{org}] [m/{machine}] [i/{installer}]`
 //!
+//! The string has two distinct regions, exposed as separate APIs:
+//!
+//! - **Platform UA** ([`platform_ua_string`]): host-tool prefix, platform
+//!   info, rattler/reqwest versions. Non-identifying; safe to send to any
+//!   domain.
+//! - **Identity tokens** ([`identity_tokens`]): `aau/ c/ s/ e/ a/ i/ o/ m/`.
+//!   Only appropriate for Anaconda-operated domains where the consumer has
+//!   opted in to telemetry.
+//!
+//! [`token_string`] is the concatenation of both, for callers that want the
+//! full User-Agent at an Anaconda-operated domain.
+//!
 //! # Usage
 //!
 //! ```no_run
@@ -20,9 +32,12 @@
 //!     ..Default::default()
 //! };
 //!
-//! // Full token string (for User-Agent headers)
+//! // Full token string (for User-Agent headers at Anaconda-operated domains)
 //! // e.g., "ana/0.1.0 rattler/0.40.5 Darwin/25.2.0 OSX/26.2 aau/0.7.6 c/... s/..."
 //! let tokens = token_string(&config);
+//!
+//! // Non-identifying platform UA (safe for any domain)
+//! let platform_ua = anaconda_anon_usage::platform_ua_string(&(&config).into());
 //!
 //! // Per-token details (for diagnostics)
 //! for entry in token_details(&config) {
@@ -106,6 +121,57 @@ impl Default for Config {
     }
 }
 
+/// Inputs for the non-identifying portion of the User-Agent.
+///
+/// All fields are either compile-time-constant or first-boot-static, so a
+/// [`PlatformUaConfig`] is safe to hash and use as a cache key.
+/// Derived from [`Config`] via `From`/`Into`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PlatformUaConfig {
+    /// Host-tool prefix (e.g., `"ana/0.1.0"`). Whitespace-delimited words
+    /// become individual entries.
+    pub prefix: Option<String>,
+
+    /// If `true`, platform tokens (e.g., `Darwin/25.2.0 OSX/26.2 rustc/1.82.0`)
+    /// are included. See [`Config::platform`] for the default.
+    pub platform: bool,
+
+    /// Rattler version override. Same semantics as [`Config::rattler_version`].
+    pub rattler_version: Option<String>,
+
+    /// Reqwest version override. Same semantics as [`Config::reqwest_version`].
+    pub reqwest_version: Option<String>,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for PlatformUaConfig {
+    fn default() -> Self {
+        Self {
+            prefix: None,
+            platform: cfg!(feature = "platform"),
+            rattler_version: None,
+            reqwest_version: None,
+        }
+    }
+}
+
+impl From<&Config> for PlatformUaConfig {
+    fn from(c: &Config) -> Self {
+        Self {
+            prefix: c.prefix.clone(),
+            platform: c.platform,
+            rattler_version: c.rattler_version.clone(),
+            reqwest_version: c.reqwest_version.clone(),
+        }
+    }
+}
+
+impl From<Config> for PlatformUaConfig {
+    fn from(c: Config) -> Self {
+        (&c).into()
+    }
+}
+
 /// A collected token with its provenance (where it came from).
 pub struct TokenEntry {
     /// Token name/prefix (e.g., `"c"`, `"aau"`, `"Darwin"`, `"ana"`).
@@ -177,16 +243,52 @@ pub(crate) struct DeferredWrite {
     pub label: String,
 }
 
-/// Build the full token string.
+/// Build the non-identifying portion of the User-Agent.
 ///
-/// Format: `[prefix...] [reqwest/{ver}] [platform...] [rattler/{ver}] aau/{version} c/{client} s/{session} e/{env} [a/{cloud}] [o/{org}] [m/{machine}] [i/{installer}]`
-pub fn token_string(config: &Config) -> String {
-    match tokens::token_string(config) {
+/// Format: `[prefix...] [reqwest/{ver}] [platform...] [rattler/{ver}]`
+///
+/// Safe to send to any domain — contains only the host-tool prefix,
+/// platform information, and crate versions. None of these are
+/// user-identifying; all are compile-time-constant or first-boot-static.
+///
+/// The result is cached per-[`PlatformUaConfig`] for the process lifetime.
+pub fn platform_ua_string(config: &PlatformUaConfig) -> String {
+    tokens::platform_ua_string(config)
+}
+
+/// Build just the identity-bearing portion of the token string.
+///
+/// Format: `aau/{version} c/{client} s/{session} e/{env} [a/{cloud}] [i/{installer}] [o/{org}] [m/{machine}]`
+///
+/// Only appropriate to send to Anaconda-operated domains where the
+/// consumer has opted in to telemetry. For non-Anaconda domains, use
+/// [`platform_ua_string`] alone.
+pub fn identity_tokens(config: &Config) -> String {
+    match tokens::identity_tokens(config) {
         Ok(s) => s,
         Err(e) => {
             tracing::error!("Failed to generate AAU tokens: {}", e);
             format!("aau/{}", VERSION)
         }
+    }
+}
+
+/// Build the full token string (platform UA + identity tokens).
+///
+/// Format: `[prefix...] [reqwest/{ver}] [platform...] [rattler/{ver}] aau/{version} c/{client} s/{session} e/{env} [a/{cloud}] [o/{org}] [m/{machine}] [i/{installer}]`
+///
+/// This is the full User-Agent for requests to Anaconda-operated domains.
+/// For requests to non-Anaconda domains, use [`platform_ua_string`] alone
+/// to avoid sending identity tokens off-platform.
+pub fn token_string(config: &Config) -> String {
+    let platform = platform_ua_string(&config.into());
+    let identity = identity_tokens(config);
+    if platform.is_empty() {
+        identity
+    } else if identity.is_empty() {
+        platform
+    } else {
+        format!("{} {}", platform, identity)
     }
 }
 

--- a/rust/src/tokens.rs
+++ b/rust/src/tokens.rs
@@ -1,7 +1,7 @@
 //! Token generation and caching for all AAU token types.
 
 use super::utils::{random_token, read_file, saved_token};
-use super::{Config, Error, Result, TokenEntry, VERSION};
+use super::{Config, Error, PlatformUaConfig, Result, TokenEntry, VERSION};
 use base64::prelude::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -24,6 +24,12 @@ static TOKEN_CACHE: LazyLock<Mutex<HashMap<String, String>>> =
 // Cache for multi-valued system tokens (installer, org, machine).
 type SystemTokenMap = HashMap<String, Vec<(String, String)>>;
 static SYSTEM_TOKEN_CACHE: LazyLock<Mutex<SystemTokenMap>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+// Cache for the non-identifying platform UA string, keyed by PlatformUaConfig.
+// Inputs are all compile-time-constant or first-boot-static, so the output
+// is stable for the process lifetime.
+static PLATFORM_UA_CACHE: LazyLock<Mutex<HashMap<PlatformUaConfig, String>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Cached search paths — filesystem checks done once per process.
@@ -462,18 +468,14 @@ fn parse_prefix(prefix: &str) -> Vec<TokenEntry> {
         .collect()
 }
 
-/// Collect all AAU tokens with provenance information.
+/// Collect the non-identifying portion of the UA as `TokenEntry` values.
 ///
-/// This is the single source of truth for token assembly. The ordering is:
+/// Ordering:
 /// 1. Prefix entries (from `config.prefix`)
-/// 2. Reqwest version (if `reqwest` feature is enabled)
+/// 2. Reqwest version (if `reqwest` feature is enabled or `config.reqwest_version` is set)
 /// 3. Platform tokens (if `config.platform` is true)
-/// 4. Rattler version (if `rattler` feature is enabled)
-/// 5. AAU tokens (`aau/`, `c/`, `s/`, `e/`, `a/`, `i/`, `o/`, `m/`)
-///
-/// The token string can be exactly reproduced by joining entries as
-/// `"{prefix}/{value}"` (or just `"{prefix}"` when value is empty).
-fn collect_tokens(config: &Config) -> Result<Vec<TokenEntry>> {
+/// 4. Rattler version (if `rattler` feature is enabled or `config.rattler_version` is set)
+fn collect_platform_tokens(config: &PlatformUaConfig) -> Vec<TokenEntry> {
     let mut entries = Vec::new();
 
     // 1. Prefix entries
@@ -547,7 +549,16 @@ fn collect_tokens(config: &Config) -> Result<Vec<TokenEntry>> {
         }
     }
 
-    // 5. AAU version (always first of the AAU tokens)
+    entries
+}
+
+/// Collect the identity-bearing portion of the UA as `TokenEntry` values.
+///
+/// Ordering: `aau/ c/ s/ e/ a/ i/ o/ m/`
+fn collect_identity_tokens(config: &Config) -> Result<Vec<TokenEntry>> {
+    let mut entries = Vec::new();
+
+    // AAU version (always first of the AAU tokens)
     entries.push(TokenEntry {
         prefix: "aau".into(),
         label: "version".into(),
@@ -635,25 +646,46 @@ fn collect_tokens(config: &Config) -> Result<Vec<TokenEntry>> {
     Ok(entries)
 }
 
-/// Build the full token string.
+/// Build the non-identifying platform UA string, caching the result
+/// per-`PlatformUaConfig` for the process lifetime.
+pub fn platform_ua_string(config: &PlatformUaConfig) -> String {
+    if let Some(hit) = PLATFORM_UA_CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(config)
+        .cloned()
+    {
+        return hit;
+    }
+    let entries = collect_platform_tokens(config);
+    let value = entries_to_string(&entries);
+    tracing::debug!("Platform UA string: {}", value);
+    let mut cache = PLATFORM_UA_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    cache.entry(config.clone()).or_insert(value).clone()
+}
+
+/// Build just the identity-bearing portion of the token string.
 ///
-/// Format: `[prefix...] [reqwest/{ver}] [platform...] [rattler/{ver}] aau/{ver} c/{client} s/{session} e/{env} [a/{cloud}] [i/{installer}] [o/{org}] [m/{machine}]`
-pub fn token_string(config: &Config) -> Result<String> {
-    let entries = collect_tokens(config)?;
+/// Format: `aau/{ver} c/{client} s/{session} e/{env} [a/{cloud}] [i/{installer}] [o/{org}] [m/{machine}]`
+pub fn identity_tokens(config: &Config) -> Result<String> {
+    let entries = collect_identity_tokens(config)?;
     let result = entries_to_string(&entries);
-    tracing::debug!("Full aau token string: {}", result);
+    tracing::debug!("Identity tokens: {}", result);
     Ok(result)
 }
 
 /// Collect all AAU tokens with per-token provenance information.
 ///
-/// Returns individual token entries including the `aau/` version entry.
-/// The token string can be exactly reproduced by joining entries:
+/// Returns the concatenation of `collect_platform_tokens` followed by
+/// `collect_identity_tokens`. The token string can be exactly reproduced
+/// by joining entries:
 /// ```ignore
 /// entries.iter().map(|e| format!("{}/{}", e.prefix, e.value)).collect::<Vec<_>>().join(" ")
 /// ```
 pub fn token_details(config: &Config) -> Result<Vec<TokenEntry>> {
-    collect_tokens(config)
+    let mut entries = collect_platform_tokens(&config.into());
+    entries.extend(collect_identity_tokens(config)?);
+    Ok(entries)
 }
 
 /// Join token entries into a space-separated token string.
@@ -683,6 +715,15 @@ mod tests {
             env_prefix: Some("/nonexistent/prefix".to_string()),
             ..Default::default()
         }
+    }
+
+    /// Test helper: reproduce the legacy `token_string` shape from the
+    /// current split API. Returns the same string the public
+    /// `crate::token_string` returns on success, but propagates the
+    /// underlying `Result` for assertion ergonomics.
+    fn token_string(config: &Config) -> Result<String> {
+        let entries = token_details(config)?;
+        Ok(entries_to_string(&entries))
     }
 
     // ---- is_valid_token ----
@@ -1211,5 +1252,141 @@ mod tests {
             !search_path.contains(&override_path),
             "without test-support, override path MUST NOT appear in search path"
         );
+    }
+
+    // ---- split API: platform_ua_string / identity_tokens ----
+
+    #[test]
+    fn platform_ua_string_has_no_identity_tokens() {
+        let ua = platform_ua_string(&PlatformUaConfig {
+            prefix: Some("ana/0.1.0".into()),
+            platform: true,
+            ..Default::default()
+        });
+        for id in [" aau/", " c/", " s/", " e/", " a/", " i/", " o/", " m/"] {
+            assert!(
+                !ua.contains(id) && !ua.starts_with(id.trim_start()),
+                "platform UA must not contain identity token {:?}: {}",
+                id,
+                ua
+            );
+        }
+    }
+
+    #[test]
+    fn platform_ua_string_empty_for_default_config_without_platform() {
+        // No prefix, no platform, no rattler/reqwest — nothing to emit.
+        let ua = platform_ua_string(&PlatformUaConfig {
+            platform: false,
+            ..Default::default()
+        });
+        assert_eq!(ua, "");
+    }
+
+    #[test]
+    fn platform_ua_string_contains_prefix_and_platform() {
+        let ua = platform_ua_string(&PlatformUaConfig {
+            prefix: Some("ana/0.1.0".into()),
+            platform: true,
+            ..Default::default()
+        });
+        assert!(ua.starts_with("ana/0.1.0"), "got: {}", ua);
+        // Platform tokens are OS-specific, but at least one should be present.
+        assert!(
+            crate::platform::platform_tokens()
+                .iter()
+                .any(|pt| ua.contains(&pt.name)),
+            "expected some platform token in: {}",
+            ua
+        );
+    }
+
+    #[test]
+    fn identity_tokens_starts_with_aau_and_contains_client_session() {
+        let result = identity_tokens(&default_config()).unwrap();
+        assert!(
+            result.starts_with(&format!("aau/{}", VERSION)),
+            "{}",
+            result
+        );
+        assert!(result.contains(" c/"), "{}", result);
+        assert!(result.contains(" s/"), "{}", result);
+    }
+
+    #[test]
+    fn identity_tokens_has_no_platform_prefix_or_version_tokens() {
+        // Use a config with prefix + platform on — identity_tokens should
+        // still not emit any of the non-identifying fields.
+        let cfg = Config {
+            env_prefix: Some("/nonexistent/prefix".into()),
+            prefix: Some("ana/0.1.0".into()),
+            platform: true,
+            rattler_version: Some("1.2.3".into()),
+            reqwest_version: Some("0.12.0".into()),
+            ..Default::default()
+        };
+        let ident = identity_tokens(&cfg).unwrap();
+        assert!(!ident.contains("ana/0.1.0"), "{}", ident);
+        assert!(!ident.contains("rattler/"), "{}", ident);
+        assert!(!ident.contains("reqwest/"), "{}", ident);
+    }
+
+    #[test]
+    fn token_details_equals_platform_plus_identity() {
+        let cfg = Config {
+            env_prefix: Some("/nonexistent/prefix".into()),
+            prefix: Some("ana/0.1.0".into()),
+            platform: true,
+            ..Default::default()
+        };
+        let entries = token_details(&cfg).unwrap();
+        let joined = entries_to_string(&entries);
+
+        let platform = platform_ua_string(&(&cfg).into());
+        let ident = identity_tokens(&cfg).unwrap();
+        let expected = if platform.is_empty() {
+            ident
+        } else {
+            format!("{} {}", platform, ident)
+        };
+
+        assert_eq!(joined, expected);
+    }
+
+    #[test]
+    fn platform_ua_string_is_cached() {
+        // Use a unique prefix to avoid collisions with other tests' cache entries.
+        let cfg = PlatformUaConfig {
+            prefix: Some("aau_test_cache/42".into()),
+            platform: false,
+            ..Default::default()
+        };
+        let first = platform_ua_string(&cfg);
+        // Direct cache inspection — the value must be stored under the
+        // exact config key used to produce it.
+        let hit = PLATFORM_UA_CACHE
+            .lock()
+            .unwrap()
+            .get(&cfg)
+            .cloned()
+            .expect("platform UA should have been cached after first call");
+        assert_eq!(first, hit);
+    }
+
+    #[test]
+    fn platform_ua_config_from_config_copies_fields() {
+        let cfg = Config {
+            prefix: Some("myapp/1.0".into()),
+            platform: true,
+            rattler_version: Some("0.40.5".into()),
+            reqwest_version: Some("0.12.5".into()),
+            env_prefix: Some("/ignored".into()),
+            anaconda_jwt: Some("ignored".into()),
+        };
+        let ua: PlatformUaConfig = (&cfg).into();
+        assert_eq!(ua.prefix.as_deref(), Some("myapp/1.0"));
+        assert!(ua.platform);
+        assert_eq!(ua.rattler_version.as_deref(), Some("0.40.5"));
+        assert_eq!(ua.reqwest_version.as_deref(), Some("0.12.5"));
     }
 }


### PR DESCRIPTION
Closes #237.

## Summary

Splits the User-Agent construction along the identifying-vs-non-identifying boundary:

- **`platform_ua_string(&PlatformUaConfig)`** — host-tool prefix + platform info + rattler/reqwest versions. Non-identifying; safe to send to any domain. Cached per-config for the process lifetime.
- **`identity_tokens(&Config)`** — AAU identity tokens only: `aau/ c/ s/ e/ a/ i/ o/ m/`. Only appropriate for Anaconda-operated domains where the consumer has opted in to telemetry.
- **`token_string(&Config)`** — thin wrapper that concatenates both. Existing behavior unchanged.

`PlatformUaConfig` carries only the non-identifying inputs (`prefix`, `platform`, `rattler_version`, `reqwest_version`) and derives `From<&Config>` / `From<Config>`, so a middleware can build a platform UA from an existing `Config` without duplicating fields.

## Why split rather than add a flag

A boolean `Config::include_identity_tokens` would work but couples two concerns (what UA to construct, whether identity is appropriate) into one call. Two functions make the intent explicit at every call site: calling `platform_ua_string` is a declaration that the request is not identity-bearing. That's exactly the invariant `anaconda-middleware` wants to enforce when it decides whether a host is Anaconda-operated.

## Caching

`PlatformUaConfig` derives `PartialEq` + `Eq` + `Hash`, and `platform_ua_string` uses a `Mutex<HashMap<PlatformUaConfig, String>>` for memoization. All inputs are stable for the process lifetime, so a call during HTTP client construction is effectively free after the first.

## Downstream impact

- **`anaconda-middleware`**: call `platform_ua_string` in the `user_agent()` step of `ClientBuilder`, continue to call `token_string` only in `prepare_request` for Anaconda-domain hosts. Consumers get richer UAs on every outgoing request without code changes.
- **Direct consumers of `anaconda-anon-usage`**: additive — `token_string` unchanged, same signature, same output.

## Changes

- **`rust/src/lib.rs`** — new `PlatformUaConfig` struct with `Default` + `From<&Config>` + `From<Config>`; new public `platform_ua_string` and `identity_tokens` functions; `token_string` becomes a thin wrapper.
- **`rust/src/tokens.rs`** — `collect_tokens` split into `collect_platform_tokens(&PlatformUaConfig)` and `collect_identity_tokens(&Config)`; new `PLATFORM_UA_CACHE` static; `token_details` now concatenates both halves.
- **`rust/README.md`** — documents the new split API with an example showing `platform_ua_string` for non-Anaconda domains vs `token_string` for Anaconda domains.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --features cli -- -D warnings` passes
- [x] `cargo clippy --features cli,test-support -- -D warnings` passes
- [x] `cargo test` passes in both feature configs (79/79, up from 71 — 8 new tests covering: platform UA contains no identity tokens; identity tokens contain no platform/prefix/version tokens; `token_details` equals platform + identity concatenation; cache hit on repeated calls; `From<&Config>` field copying)
- [x] `pytest tests/test_rust_parity.py` — 60/61 (the one failure is the versioneer `.dirty` mismatch from uncommitted changes that self-resolves in CI, per prior PR convention)

## Non-goals (carried over from #237)

- Changing what goes into the identity-token portion (separate privacy/telemetry conversation)
- Changing which domains the middleware treats as Anaconda (that decision lives in middleware)
- Adding new platform facts (the current platform string is already rich; this PR is about making it available on more paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
