### PR TITLE
ci: skip rust parity tests in canary job

### DIFF
--- a/.github/workflows/canary-test.yml
+++ b/.github/workflows/canary-test.yml
@@ -81,7 +81,7 @@ jobs:
         conda activate base
         conda info 2>&1 | tee output.txt
         if grep -q 'Error loading' output.txt; then exit -1; fi
-        pytest
+        pytest --ignore=tests/test_rust_parity.py
         python tests/integration/test_config.py
     - name: Test heartbeats (pwsh)
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
## Summary
- Canary CI has been failing because it runs the full `pytest` suite, including `tests/test_rust_parity.py`, but the canary job never builds the Rust binary.
- `main.yml` already skips the parity tests via `--ignore=tests/test_rust_parity.py` — this PR applies the same flag to `canary-test.yml` so the canary job only exercises the Python package against canary `conda` builds.

## Test plan
- [ ] Trigger the canary workflow via `workflow_dispatch` and confirm it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
