### PR TITLE
Restore activation heartbeat bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ There are a few activation paths, depending on the conda version and command:
 - If both the plugin and startup hook paths run in one process, activation
   patching is idempotent.
 
+The conda package installs both `anaconda_anon_usage_activation.pth` and
+`anaconda_anon_usage_activation.start`. The `.pth` file covers current Python
+versions that still execute `import` lines at startup. The matching `.start`
+file follows [PEP 829](https://peps.python.org/pep-0829/) for Python versions
+that prefer structured `pkg.mod:callable` startup entry points and ignore the
+matching `.pth` import line.
+
 ### Rust crate
 
 A Rust implementation of this package is available as a crate:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ modify the user agent string. The conda package also installs a Python
 startup hook for shell activation commands so opt-in activation heartbeats can
 run even when conda avoids loading plugins on the activation fast path.
 
+There are a few activation paths, depending on the conda version and command:
+
+- With conda versions that support plugins, normal conda commands load the
+  pre-command plugin. That path applies the user-agent patch and keeps
+  `conda info` output redacted.
+- Older conda versions use the legacy patch variant, which installs activation
+  and link scripts to patch conda's context machinery directly.
+- Shell activation commands, such as `conda shell.posix activate`, can run on a
+  fast path that avoids plugin loading. The conda package covers that path with
+  Python startup hook files that only continue when the process is handling
+  shell activation, then install the activation heartbeat patch.
+- If both the plugin and startup hook paths run in one process, activation
+  patching is idempotent.
+
 ### Rust crate
 
 A Rust implementation of this package is available as a crate:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ conda install -n base anaconda-anon-usage
 ```
 This package has no additional dependencies other than `conda`
 itself. It employs a [conda pre-command plugin](https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/conda-plugins.html) to
-modify the user agent string.
+modify the user agent string. The conda package also installs a Python
+startup hook for shell activation commands so opt-in activation heartbeats can
+run even when conda avoids loading plugins on the activation fast path.
 
 ### Rust crate
 

--- a/anaconda_anon_usage/_activation_bootstrap.py
+++ b/anaconda_anon_usage/_activation_bootstrap.py
@@ -1,3 +1,11 @@
+"""Bootstrap activation patching from Python startup hooks.
+
+Normal conda commands use the conda pre-command plugin, but recent conda
+activation can bypass plugin loading on the shell activation fast path. This
+module is imported by startup hook files and then checks ``sys.argv`` before
+loading the heavier patching code, so unrelated Python startup remains cheap.
+"""
+
 import os
 import sys
 
@@ -9,6 +17,8 @@ def maybe_patch_activation(argv=None):
         return False
 
     try:
+        # Keep this lazy. Python startup hooks may import this module for
+        # non-activation processes, but only activation needs conda patching.
         from . import patch
 
         return patch.main(plugin=True, command="activate")

--- a/anaconda_anon_usage/_activation_bootstrap.py
+++ b/anaconda_anon_usage/_activation_bootstrap.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+
+def maybe_patch_activation(argv=None):
+    if argv is None:
+        argv = sys.argv
+    if len(argv) < 3 or not argv[1].startswith("shell.") or argv[2] != "activate":
+        return False
+
+    try:
+        from . import patch
+
+        return patch.main(plugin=True, command="activate")
+    except Exception as exc:
+        if os.environ.get("ANACONDA_ANON_USAGE_RAISE"):
+            raise
+        if os.environ.get("ANACONDA_ANON_USAGE_DEBUG"):
+            print(
+                "Error loading anaconda-anon-usage activation bootstrap: %s" % exc,
+                file=sys.stderr,
+            )
+    return False

--- a/anaconda_anon_usage/patch.py
+++ b/anaconda_anon_usage/patch.py
@@ -114,6 +114,8 @@ def _patch_activate():
     if hasattr(activate, "_Activator"):
         _Activator = activate._Activator
         if hasattr(_Activator, "activate"):
+            if hasattr(_Activator, "_old_activate"):
+                return
             _Activator._old_activate = _Activator.activate
             _Activator.activate = _new_activate
             return

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -2,6 +2,8 @@
 "${PREFIX}/bin/python" -m pip install --no-deps --ignore-installed -vv .
 if [ "$NEED_SCRIPTS" != yes ]; then
     rm ${SP_DIR}/anaconda_anon_usage/install.py
+    # Ship both Python startup hook forms: .pth for current Python releases and
+    # .start for PEP 829-capable Python releases.
     cp \
         "scripts/anaconda_anon_usage_activation.pth" \
         "${SP_DIR}/anaconda_anon_usage_activation.pth"

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -2,6 +2,12 @@
 "${PREFIX}/bin/python" -m pip install --no-deps --ignore-installed -vv .
 if [ "$NEED_SCRIPTS" != yes ]; then
     rm ${SP_DIR}/anaconda_anon_usage/install.py
+    cp \
+        "scripts/anaconda_anon_usage_activation.pth" \
+        "${SP_DIR}/anaconda_anon_usage_activation.pth"
+    cp \
+        "scripts/anaconda_anon_usage_activation.start" \
+        "${SP_DIR}/anaconda_anon_usage_activation.start"
     exit 0
 fi
 rm ${SP_DIR}/anaconda_anon_usage/plugin.py

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -49,6 +49,8 @@ test:
     - anaconda-anon-usage --no-keyring | grep -q "^aau/"
     - ANACONDA_ANON_USAGE_DEBUG=1 conda info
     - conda info | grep -q "user-agent.* aau/"
+    - python -c "import site, pathlib; assert any((pathlib.Path(p) / 'anaconda_anon_usage_activation.pth').is_file() for p in site.getsitepackages())"  # [variant=="plugin"]
+    - python -c "import site, pathlib; assert any((pathlib.Path(p) / 'anaconda_anon_usage_activation.start').is_file() for p in site.getsitepackages())"  # [variant=="plugin"]
 
 about:
   home: https://github.com/Anaconda-Platform/anaconda-anon-usage

--- a/scripts/anaconda_anon_usage_activation.pth
+++ b/scripts/anaconda_anon_usage_activation.pth
@@ -1,0 +1,1 @@
+import sys; len(sys.argv) > 2 and sys.argv[1].startswith("shell.") and sys.argv[2] == "activate" and __import__("anaconda_anon_usage._activation_bootstrap", fromlist=["maybe_patch_activation"]).maybe_patch_activation()

--- a/scripts/anaconda_anon_usage_activation.start
+++ b/scripts/anaconda_anon_usage_activation.start
@@ -1,0 +1,1 @@
+anaconda_anon_usage._activation_bootstrap:maybe_patch_activation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,18 +139,28 @@ def client_token_string_cache_cleanup(request):
 @pytest.fixture(autouse=True)
 def reset_patch(request):
     def _resetter():
+        from conda import activate
         from conda.cli import install as cli_install
         from conda.cli import main_info
 
-        for k in ("___new_user_agent", "__user_agent", "anaconda_anon_usage"):
+        for k in (
+            "___new_user_agent",
+            "__user_agent",
+            "anaconda_anon_usage",
+            "anaconda_heartbeat",
+        ):
             context._cache_.pop(k, None)
         context._aau_initialized = None
         if hasattr(Context, "anaconda_anon_usage"):
             delattr(Context, "anaconda_anon_usage")
+        if hasattr(Context, "anaconda_heartbeat"):
+            delattr(Context, "anaconda_heartbeat")
         if hasattr(Context, "checked_prefix"):
             delattr(Context, "checked_prefix")
         Context.parameter_names = tuple(
-            k for k in Context.parameter_names if k != "anaconda_anon_usage"
+            k
+            for k in Context.parameter_names
+            if k not in {"anaconda_anon_usage", "anaconda_heartbeat"}
         )
         orig_check_prefix = getattr(Context, "_old_check_prefix", None)
         if orig_check_prefix is not None:
@@ -161,9 +171,17 @@ def reset_patch(request):
         if orig_user_agent is not None:
             Context.user_agent = orig_user_agent
             delattr(Context, "_old_user_agent")
-        orig_get_main_info_str = getattr(main_info, "_old_get_main_info_str", None)
+        activator = getattr(activate, "_Activator", None)
+        orig_activate = getattr(activator, "_old_activate", None)
+        if orig_activate is not None:
+            activator.activate = orig_activate
+            delattr(activator, "_old_activate")
+        orig_get_main_info_str = getattr(Context, "_old_get_main_info_str", None)
         if orig_get_main_info_str is not None:
-            main_info.get_main_info_str = orig_get_main_info_str
+            if hasattr(main_info, "get_main_info_display"):
+                main_info.get_main_info_display = orig_get_main_info_str
+            elif hasattr(main_info, "get_main_info_str"):
+                main_info.get_main_info_str = orig_get_main_info_str
             delattr(Context, "_old_get_main_info_str")
 
     request.addfinalizer(_resetter)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,10 @@ from os import mkdir
 from os.path import dirname, join
 
 import pytest
+from conda import activate
 from conda.base.context import Context, context
+from conda.cli import install as cli_install
+from conda.cli import main_info
 
 from anaconda_anon_usage import tokens, utils
 
@@ -139,10 +142,6 @@ def client_token_string_cache_cleanup(request):
 @pytest.fixture(autouse=True)
 def reset_patch(request):
     def _resetter():
-        from conda import activate
-        from conda.cli import install as cli_install
-        from conda.cli import main_info
-
         for k in (
             "___new_user_agent",
             "__user_agent",

--- a/tests/unit/test_activation_bootstrap.py
+++ b/tests/unit/test_activation_bootstrap.py
@@ -1,0 +1,81 @@
+import sys
+
+import pytest
+
+from anaconda_anon_usage import _activation_bootstrap
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["conda"],
+        ["conda", "info"],
+        ["conda", "shell.posix"],
+        ["conda", "shell.posix", "reactivate"],
+    ],
+)
+def test_maybe_patch_activation_skips_non_shell_activate(mocker, argv):
+    patch_main = mocker.patch("anaconda_anon_usage.patch.main")
+
+    assert _activation_bootstrap.maybe_patch_activation(argv) is False
+    patch_main.assert_not_called()
+
+
+@pytest.mark.parametrize("shell", ["shell.posix", "shell.posix+json"])
+def test_maybe_patch_activation_patches_shell_activate(mocker, shell):
+    patch_main = mocker.patch("anaconda_anon_usage.patch.main")
+
+    assert (
+        _activation_bootstrap.maybe_patch_activation(["conda", shell, "activate"])
+        is patch_main.return_value
+    )
+
+    patch_main.assert_called_once_with(plugin=True, command="activate")
+
+
+def test_maybe_patch_activation_defaults_to_sys_argv(mocker, monkeypatch):
+    patch_main = mocker.patch("anaconda_anon_usage.patch.main")
+    monkeypatch.setattr(sys, "argv", ["conda", "shell.posix", "activate"])
+
+    assert _activation_bootstrap.maybe_patch_activation() is patch_main.return_value
+
+    patch_main.assert_called_once_with(plugin=True, command="activate")
+
+
+def test_maybe_patch_activation_swallows_errors_by_default(mocker, capsys):
+    mocker.patch("anaconda_anon_usage.patch.main", side_effect=RuntimeError("failed"))
+
+    assert (
+        _activation_bootstrap.maybe_patch_activation(
+            ["conda", "shell.posix", "activate"]
+        )
+        is False
+    )
+
+    assert capsys.readouterr().err == ""
+
+
+def test_maybe_patch_activation_reports_errors_in_debug(mocker, monkeypatch, capsys):
+    mocker.patch("anaconda_anon_usage.patch.main", side_effect=RuntimeError("failed"))
+    monkeypatch.setenv("ANACONDA_ANON_USAGE_DEBUG", "1")
+
+    assert (
+        _activation_bootstrap.maybe_patch_activation(
+            ["conda", "shell.posix", "activate"]
+        )
+        is False
+    )
+
+    assert "Error loading anaconda-anon-usage activation bootstrap: failed" in (
+        capsys.readouterr().err
+    )
+
+
+def test_maybe_patch_activation_reraises_when_requested(mocker, monkeypatch):
+    mocker.patch("anaconda_anon_usage.patch.main", side_effect=RuntimeError("failed"))
+    monkeypatch.setenv("ANACONDA_ANON_USAGE_RAISE", "1")
+
+    with pytest.raises(RuntimeError, match="failed"):
+        _activation_bootstrap.maybe_patch_activation(
+            ["conda", "shell.posix", "activate"]
+        )

--- a/tests/unit/test_activation_bootstrap.py
+++ b/tests/unit/test_activation_bootstrap.py
@@ -42,9 +42,7 @@ def test_maybe_patch_activation_defaults_to_sys_argv(mocker, monkeypatch):
     patch_main.assert_called_once_with(plugin=True, command="activate")
 
 
-def test_maybe_patch_activation_swallows_errors_by_default(
-    mocker, monkeypatch, capsys
-):
+def test_maybe_patch_activation_swallows_errors_by_default(mocker, monkeypatch, capsys):
     mocker.patch("anaconda_anon_usage.patch.main", side_effect=RuntimeError("failed"))
     monkeypatch.delenv("ANACONDA_ANON_USAGE_RAISE", raising=False)
     monkeypatch.delenv("ANACONDA_ANON_USAGE_DEBUG", raising=False)

--- a/tests/unit/test_activation_bootstrap.py
+++ b/tests/unit/test_activation_bootstrap.py
@@ -42,8 +42,12 @@ def test_maybe_patch_activation_defaults_to_sys_argv(mocker, monkeypatch):
     patch_main.assert_called_once_with(plugin=True, command="activate")
 
 
-def test_maybe_patch_activation_swallows_errors_by_default(mocker, capsys):
+def test_maybe_patch_activation_swallows_errors_by_default(
+    mocker, monkeypatch, capsys
+):
     mocker.patch("anaconda_anon_usage.patch.main", side_effect=RuntimeError("failed"))
+    monkeypatch.delenv("ANACONDA_ANON_USAGE_RAISE", raising=False)
+    monkeypatch.delenv("ANACONDA_ANON_USAGE_DEBUG", raising=False)
 
     assert (
         _activation_bootstrap.maybe_patch_activation(
@@ -57,6 +61,7 @@ def test_maybe_patch_activation_swallows_errors_by_default(mocker, capsys):
 
 def test_maybe_patch_activation_reports_errors_in_debug(mocker, monkeypatch, capsys):
     mocker.patch("anaconda_anon_usage.patch.main", side_effect=RuntimeError("failed"))
+    monkeypatch.delenv("ANACONDA_ANON_USAGE_RAISE", raising=False)
     monkeypatch.setenv("ANACONDA_ANON_USAGE_DEBUG", "1")
 
     assert (

--- a/tests/unit/test_patch.py
+++ b/tests/unit/test_patch.py
@@ -1,6 +1,9 @@
 import re
 
+from conda import activate
 from conda.base.context import context
+from conda.cli import install as cli_install
+from conda.cli import main_info
 
 from anaconda_anon_usage import patch, tokens
 
@@ -60,8 +63,6 @@ def test_main_already_patched():
 
 
 def test_patch_activate_idempotent():
-    from conda import activate
-
     patch._patch_activate()
     old_activate = activate._Activator._old_activate
     new_activate = activate._Activator.activate
@@ -75,8 +76,6 @@ def test_patch_activate_idempotent():
 def test_patch_check_prefix_missing(monkeypatch):
     """When conda.cli.install.check_prefix doesn't exist, patching
     should skip gracefully and still mark initialization as complete."""
-    from conda.cli import install as cli_install
-
     monkeypatch.delattr(cli_install, "check_prefix", raising=False)
     patch.main(plugin=True, command="info")
     assert context._aau_initialized is True
@@ -91,7 +90,6 @@ def test_main_info():
     for tok in ALL - {"aau"}:
         if tok in tokens:
             tokens[tok] = "."
-    from conda.cli import main_info
 
     info_dict = main_info.get_info_dict()
     assert info_dict["user_agent"] == context.user_agent

--- a/tests/unit/test_patch.py
+++ b/tests/unit/test_patch.py
@@ -59,6 +59,19 @@ def test_main_already_patched():
     assert not response
 
 
+def test_patch_activate_idempotent():
+    from conda import activate
+
+    patch._patch_activate()
+    old_activate = activate._Activator._old_activate
+    new_activate = activate._Activator.activate
+
+    patch._patch_activate()
+
+    assert activate._Activator._old_activate is old_activate
+    assert activate._Activator.activate is new_activate
+
+
 def test_patch_check_prefix_missing(monkeypatch):
     """When conda.cli.install.check_prefix doesn't exist, patching
     should skip gracefully and still mark initialization as complete."""


### PR DESCRIPTION
## Summary

- Add a narrowly gated Python startup bootstrap for `conda shell.* activate` so activation can still install the heartbeat patch when conda skips plugin loading.
- Install matching `anaconda_anon_usage_activation.pth` and `anaconda_anon_usage_activation.start` startup hook files in the plugin package variant.
- Make activation patching idempotent and reset activation/context patch state in unit tests.
- Document the plugin, legacy patch, shell activation fast-path, and Python startup hook paths.

## Context

conda/conda#15877 skips loading plugins on the shell activation fast path when the plugin manager has not already been loaded. `anaconda-anon-usage` relied on its pre-command plugin to patch `_Activator.activate`, so opted-in activation heartbeats could be skipped on cold activation commands.

This keeps the conda plugin variant as the normal path for non-activation commands and user-agent patching. The startup hook is scoped to activation only.

The package ships both startup hook formats intentionally. The `.pth` file covers current Python releases that still execute startup `import` lines. The matching `.start` file follows [PEP 829](https://peps.python.org/pep-0829/) for Python versions that prefer structured `pkg.mod:callable` startup entry points and ignore the matching `.pth` import line.

## Validation

- `python3 -m py_compile anaconda_anon_usage/_activation_bootstrap.py anaconda_anon_usage/patch.py tests/conftest.py tests/unit/test_activation_bootstrap.py tests/unit/test_patch.py`
- `PYTHONPATH=. python -m pytest --no-cov tests/unit/test_activation_bootstrap.py tests/unit/test_patch.py`
- `git diff --check`

`conda build` was not run locally because `conda-build` is not installed in the local base environment.
